### PR TITLE
Allowing full maven packaging from cli (with dependencies)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,47 @@
 					<target>19</target>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>3.5.1</version>
+				<executions>
+					<execution>
+						<id>build-single</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>.</outputDirectory>
+							<finalName>singlerun</finalName>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<mainClass>simpaths.experiment.SimPathsStart</mainClass>
+								</transformer>
+							</transformers>
+						</configuration>
+					</execution>
+					<execution>
+						<id>build-multirun</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>.</outputDirectory>
+							<finalName>multirun</finalName>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<mainClass>simpaths.experiment.SimPathsMultiRun</mainClass>
+								</transformer>
+							</transformers>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
         </plugins>
 	</build>
 	<dependencies>


### PR DESCRIPTION
A working version of https://github.com/matteorichiardi/labsim/pull/32 for the new repo. Fixed as per [this SO question](https://stackoverflow.com/questions/67884617/apache-poi-excel-writer-works-in-ide-but-not-in-fat-jar-java-io-ioexception-yo).

This is a suggested option of allowing the building of `.jar` files with maven, without needing any IDE. After cloning the repository you can run:
```
$ mvn clean package
```
in the root repository to create two runnable jars:
```
.
SimPaths/
      ...
      |-- multirun.jar
      |-- singlerun.jar
      `-- src
```

These can be run with the command line (with arguments) e.g.:
```
$ java -jar singlerun.jar
$ java -jar multirun.jar -r 100 -p 50000 -n 20 -s 2017 -e 2020 -g false -f
```
This should be a small addition of code which doesn't affect any other aspects of SimPaths running via an IDE.