### PR TITLE
Added cli option to write console output to file

### DIFF
--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -84,7 +84,11 @@ public class SimPathsMultiRun extends MultiRun {
 			}
 			else if (args[i].equals("-f")){             //Output to file
 				try {
-					System.setOut(new PrintStream(new BufferedOutputStream(new FileOutputStream("output/logs/run_" + randomSeed + ".txt")), true));
+					File logDir = new File("output/logs");
+					if (!logDir.exists()) {
+						logDir.mkdirs();
+					}
+					System.setOut(new PrintStream(new BufferedOutputStream(new FileOutputStream(logDir.getPath() + "/run_" + randomSeed + ".txt")), true));
 				} catch (FileNotFoundException e) {
 					throw new RuntimeException(e);
 				}

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -11,7 +11,7 @@ import microsim.engine.SimulationEngine;
 import microsim.gui.shell.MultiRunFrame;
 import simpaths.model.enums.Country;
 
-import java.io.File;
+import java.io.*;
 
 public class SimPathsMultiRun extends MultiRun {
 
@@ -81,6 +81,13 @@ public class SimPathsMultiRun extends MultiRun {
 			else if (args[i].equals("-p")){				//Set population size
 				popSize = Integer.parseInt(args[i+1]);
 				i++;
+			}
+			else if (args[i].equals("-f")){             //Output to file
+				try {
+					System.setOut(new PrintStream(new BufferedOutputStream(new FileOutputStream("output/logs/run_" + randomSeed + ".txt")), true));
+				} catch (FileNotFoundException e) {
+					throw new RuntimeException(e);
+				}
 			}
 		}
 		


### PR DESCRIPTION
This is primarily useful when doing parallel multiruns in order to capture the output of each run to a file. When logging implementation is fixed, this could also include setting location of output logs.