### PR TITLE
Experimental/multirun logs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,11 @@
 			<version>5.9.2</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>2.20.0</version>
+		</dependency>
 	</dependencies>
 
 	<repositories>

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -2,6 +2,7 @@
 package simpaths.experiment;
 
 // import Java packages
+import org.apache.log4j.Level;
 import simpaths.data.Parameters;
 import simpaths.model.SimPathsModel;
 import microsim.data.MultiKeyCoefficientMap;
@@ -106,6 +107,7 @@ public class SimPathsMultiRun extends MultiRun {
 					appender.setAppend(false);
 					appender.setLayout(new PatternLayout("%d{yyyy MMM dd HH:mm:ss} - %m%n"));
 					appender.activateOptions();
+					Logger.getRootLogger().setLevel(Level.TRACE);
 					Logger.getRootLogger().addAppender(appender);
 				} catch (FileNotFoundException e) {
 					throw new RuntimeException(e);

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -114,6 +114,8 @@ public class SimPathsMultiRun extends MultiRun {
 				}
 			}
 		}
+
+		log.info("Starting run with seed = " + randomSeed);
 		
 		SimulationEngine engine = SimulationEngine.getInstance();
 		

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -34,6 +34,7 @@ public class SimPathsMultiRun extends MultiRun {
 	
 	private static Long randomSeed = 615L;
 
+	public static Logger log = Logger.getLogger(SimPathsMultiRun.class);
 	/**
 	 *
 	 * 	MAIN PROGRAM ENTRY FOR MULTI-SIMULATION
@@ -42,7 +43,6 @@ public class SimPathsMultiRun extends MultiRun {
 	public static void main(String[] args) {
 
 
-		public static Logger log = Logger.getLogger(SimPathsMultiRun.class);
 
 		//Adjust the country and year to the value read from Excel, which is updated when the database is rebuilt. Otherwise it will set the country and year to the last one used to build the database
 		MultiKeyCoefficientMap lastDatabaseCountryAndYear = ExcelAssistant.loadCoefficientMap("input" + File.separator + Parameters.DatabaseCountryYearFilename + ".xlsx", "Data", 1, 1);

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -11,6 +11,11 @@ import microsim.engine.SimulationEngine;
 import microsim.gui.shell.MultiRunFrame;
 import simpaths.model.enums.Country;
 
+// Logging and file writing
+import simpaths.model.SimPathsModel;
+import org.apache.log4j.FileAppender;
+import org.apache.log4j.Logger;
+import org.apache.log4j.PatternLayout;
 import java.io.*;
 
 public class SimPathsMultiRun extends MultiRun {
@@ -35,6 +40,9 @@ public class SimPathsMultiRun extends MultiRun {
 	 *
 	 */
 	public static void main(String[] args) {
+
+
+		public static Logger log = Logger.getLogger(SimPathsMultiRun.class);
 
 		//Adjust the country and year to the value read from Excel, which is updated when the database is rebuilt. Otherwise it will set the country and year to the last one used to build the database
 		MultiKeyCoefficientMap lastDatabaseCountryAndYear = ExcelAssistant.loadCoefficientMap("input" + File.separator + Parameters.DatabaseCountryYearFilename + ".xlsx", "Data", 1, 1);
@@ -88,7 +96,17 @@ public class SimPathsMultiRun extends MultiRun {
 					if (!logDir.exists()) {
 						logDir.mkdirs();
 					}
+					// Writing console outputs to `run_[seed].txt
 					System.setOut(new PrintStream(new BufferedOutputStream(new FileOutputStream(logDir.getPath() + "/run_" + randomSeed + ".txt")), true));
+
+					// Writing logs to `run_[seed].log`
+					FileAppender appender = new FileAppender();
+					appender.setName("Run logging");
+					appender.setFile(logDir.getPath() + "/run_" + randomSeed + ".log");
+					appender.setAppend(false);
+					appender.setLayout(new PatternLayout("%d{yyyy MMM dd HH:mm:ss} - %m%n"));
+					appender.activateOptions();
+					Logger.getRootLogger().addAppender(appender);
 				} catch (FileNotFoundException e) {
 					throw new RuntimeException(e);
 				}

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -107,7 +107,7 @@ public class SimPathsMultiRun extends MultiRun {
 					appender.setAppend(false);
 					appender.setLayout(new PatternLayout("%d{yyyy MMM dd HH:mm:ss} - %m%n"));
 					appender.activateOptions();
-					Logger.getRootLogger().setLevel(Level.TRACE);
+					Logger.getRootLogger().setLevel(Level.INFO);
 					Logger.getRootLogger().addAppender(appender);
 				} catch (FileNotFoundException e) {
 					throw new RuntimeException(e);

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -107,7 +107,7 @@ public class SimPathsMultiRun extends MultiRun {
 					appender.setAppend(false);
 					appender.setLayout(new PatternLayout("%d{yyyy MMM dd HH:mm:ss} - %m%n"));
 					appender.activateOptions();
-					Logger.getRootLogger().setLevel(Level.INFO);
+					Logger.getRootLogger().setLevel(Level.DEBUG);
 					Logger.getRootLogger().addAppender(appender);
 				} catch (FileNotFoundException e) {
 					throw new RuntimeException(e);

--- a/src/main/java/simpaths/model/BenefitUnit.java
+++ b/src/main/java/simpaths/model/BenefitUnit.java
@@ -1652,7 +1652,7 @@ public class BenefitUnit implements EventListener, IDoubleSource, Weight, Compar
 
 			// populate labour supply
 			if(model.debugCommentsOn && labourSupplyChoice!=null) {
-				log.debug("labour supply choice " + labourSupplyChoice);
+				log.trace("labour supply choice " + labourSupplyChoice);
 			}
 			if(Occupancy.Couple.equals(occupancy)) {
 				male.setLabourSupplyWeekly(labourSupplyChoice.getKey(0));


### PR DESCRIPTION
Hi @pbronka and @justin-ven - this is a relatively minor possible addition that I have found useful in debugging multiruns. It adds an output when the `-f` argument is used in multiruns to also write a 'run_[seed].log' file with 'DEBUG' levels of logging output. Shouldn't affect most runs or any runs without the `-f` flag. Discard if not useful or not in line with what's being developed logging-wise.