### PR TITLE
changed AUTO_SERVER to false to block extra connections

### DIFF
--- a/src/main/java/simpaths/model/SimPathsModel.java
+++ b/src/main/java/simpaths/model/SimPathsModel.java
@@ -2237,7 +2237,7 @@ public class SimPathsModel extends AbstractSimulationManager implements EventLis
 				Class.forName("org.h2.Driver");
 				System.out.print("Reading from database at " + DatabaseUtils.databaseInputUrl);
 				try {
-					conn = DriverManager.getConnection("jdbc:h2:"+DatabaseUtils.databaseInputUrl + ";AUTO_SERVER=TRUE", "sa", "");
+					conn = DriverManager.getConnection("jdbc:h2:"+DatabaseUtils.databaseInputUrl + ";AUTO_SERVER=FALSE", "sa", "");
 				}
 				catch (SQLException e) {
 					log.info(e.getMessage());


### PR DESCRIPTION
This solves #24 in one sense, by stopping runs from interfering with one another. Each waits patiently and retries after 2s if there's another run already accessing/changing tables.

**Don't merge if not the correct solution!!**

Under this change, all runs after run=1 are essentially working across two databases - root and mutirunId folders. Is this expected?