### PR TITLE
Only re-create Person, Household and BenefitUnit tables on first iteration

### DIFF
--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -112,6 +112,7 @@ public class SimPathsMultiRun extends MultiRun {
 	public void buildExperiment(SimulationEngine engine) {
 		SimPathsModel model = new SimPathsModel(Country.IT.getCountryFromNameString(countryString), startYear);
 		model.setEndYear(endYear);
+		model.setFirstRun(counter == 0);
 //		SimPathsModel model = new SimPathsModel();
 		setCountry(model);		//Set country based on input arguments.
 		model.setPopSize(popSize);

--- a/src/main/java/simpaths/model/SimPathsModel.java
+++ b/src/main/java/simpaths/model/SimPathsModel.java
@@ -61,6 +61,16 @@ import simpaths.model.taxes.DonorTaxUnitPolicy;
  */
 public class SimPathsModel extends AbstractSimulationManager implements EventListener {
 
+	public boolean isFirstRun() {
+		return isFirstRun;
+	}
+
+	public void setFirstRun(boolean firstRun) {
+		isFirstRun = firstRun;
+	}
+
+	private boolean isFirstRun;
+
 	// default simulation parameters
 	private static Logger log = Logger.getLogger(SimPathsModel.class);
 
@@ -2258,21 +2268,24 @@ public class SimPathsModel extends AbstractSimulationManager implements EventLis
 				//If user chooses start year that is higher than the last available initial population, last available population should be used but with uprated monetary values
 				boolean uprateInitialPopulation = (startYear > Parameters.getMaxStartYear());
 
-				//Create database tables to be used in simulation from country-specific tables
-				String[] tableNames = new String[]{"PERSON", "DONORPERSON", "BENEFITUNIT", "DONORTAXUNIT", "HOUSEHOLD"};
-				String[] tableNamesInitial = new String[]{"PERSON", "BENEFITUNIT", "HOUSEHOLD"};
-				String[] tableNamesDonor = new String[]{"DONORPERSON", "DONORTAXUNIT"};
 				stat = conn.createStatement();
-				for(String tableName: tableNamesDonor) {
-					stat.execute("DROP TABLE IF EXISTS " + tableName);
-					stat.execute("CREATE TABLE " + tableName + " AS SELECT * FROM " + tableName + "_" + country);
-				}
-				for(String tableName: tableNamesInitial) {
-					stat.execute("DROP TABLE IF EXISTS " + tableName);
-					if (uprateInitialPopulation) {
-						stat.execute("CREATE TABLE " + tableName + " AS SELECT * FROM " + tableName + "_" + country + "_" + Parameters.getMaxStartYear()); // Load the last available initial population from all available in tables of the database
-					} else {
-						stat.execute("CREATE TABLE " + tableName + " AS SELECT * FROM " + tableName + "_" + country + "_" + startYear); // Load the country-year specific initial population from all available in tables of the database
+
+				if (isFirstRun) {
+					//Create database tables to be used in simulation from country-specific tables
+					String[] tableNames = new String[]{"PERSON", "DONORPERSON", "BENEFITUNIT", "DONORTAXUNIT", "HOUSEHOLD"};
+					String[] tableNamesInitial = new String[]{"PERSON", "BENEFITUNIT", "HOUSEHOLD"};
+					String[] tableNamesDonor = new String[]{"DONORPERSON", "DONORTAXUNIT"};
+					for (String tableName : tableNamesDonor) {
+						stat.execute("DROP TABLE IF EXISTS " + tableName);
+						stat.execute("CREATE TABLE " + tableName + " AS SELECT * FROM " + tableName + "_" + country);
+					}
+					for (String tableName : tableNamesInitial) {
+						stat.execute("DROP TABLE IF EXISTS " + tableName);
+						if (uprateInitialPopulation) {
+							stat.execute("CREATE TABLE " + tableName + " AS SELECT * FROM " + tableName + "_" + country + "_" + Parameters.getMaxStartYear()); // Load the last available initial population from all available in tables of the database
+						} else {
+							stat.execute("CREATE TABLE " + tableName + " AS SELECT * FROM " + tableName + "_" + country + "_" + startYear); // Load the country-year specific initial population from all available in tables of the database
+						}
 					}
 				}
 
@@ -2286,7 +2299,7 @@ public class SimPathsModel extends AbstractSimulationManager implements EventLis
 				}
 
 				//If start year is higher than the last available population, calculate the uprating factor and apply it to the monetary values in the database:
-				if (uprateInitialPopulation) {
+				if (uprateInitialPopulation & isFirstRun) {
 					double upratingFactor =
 							Parameters.getTimeSeriesIndex(startYear, UpratingCase.ModelInitialise) /
 									Parameters.getTimeSeriesIndex(Parameters.getMaxStartYear(), UpratingCase.ModelInitialise);


### PR DESCRIPTION
This is another possible solution to #24 - works by *not* dropping/re-creating the tables on subsequent iterations (within each multirun). This goes in conjunction with https://github.com/jasmineRepo/JAS-mine-core/pull/41 which keeps the database url constant. Both of these are needed to solve the database conflict problems between parallel runs.

One minor thing was I experimented with was not running `inputDatabaseInteraction()` at all on iteration 2, as not needing to re-establish a new connection each time would be a bit more efficient (when I had effectively disabled most of the operations being done with that connection). However, it failed because these lines were necessary for the initialising of a new population for iteration 2:
https://github.com/centreformicrosimulation/SimPaths/blob/2909099624042b85b1723d044ada3328bc6cc00b/src/main/java/simpaths/model/SimPathsModel.java#L2285-L2292

As a side query about this - can this initialisation of `initialHoursWorkedWeekly` from the `PERSON` table be done from the persistence database connection rather than establishing a new connection in `inputDatabaseInteraction()`?

Thanks for help/review of this @pbronka @justin-ven 