### PR TITLE
Experimental/arg parsing

### DIFF
--- a/.github/workflows/SimPathsBuild.yml
+++ b/.github/workflows/SimPathsBuild.yml
@@ -53,7 +53,7 @@ jobs:
         path: .
 
     - name: Setup run
-      run: java -jar singlerun.jar -c UK -y 2017 -Setup -g false
+      run: java -jar singlerun.jar -c UK -s 2017 -Setup -g false
 
     - name: Do one run
       run: java -jar multirun.jar -p 50000 -s 2017 -e 2020 -r 100 -n 2 -g false

--- a/pom.xml
+++ b/pom.xml
@@ -78,8 +78,11 @@
 		    <artifactId>commons-lang3</artifactId>
 		    <version>3.12.0</version>
 		</dependency>
-		<!--
-		-->
+		<dependency>
+			<groupId>commons-cli</groupId>
+			<artifactId>commons-cli</artifactId>
+			<version>1.4</version> <!-- Use the latest version available -->
+		</dependency>
 		<dependency>
 			<groupId>com.github.jasmineRepo</groupId>
 			<artifactId>JAS-mine-core</artifactId>

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -89,7 +89,7 @@ public class SimPathsMultiRun extends MultiRun {
 
 			if (cmd.hasOption("h")) {
 				printHelpMessage(formatter, options);
-				System.exit(0); // Exit without reporting an error
+				return; // Exit without reporting an error
 			}
 			if (cmd.hasOption("n")) {
 				maxNumberOfRuns = Integer.parseInt(cmd.getOptionValue("n"));
@@ -163,7 +163,7 @@ public class SimPathsMultiRun extends MultiRun {
 	}
 
 	private static void printHelpMessage(HelpFormatter formatter, Options options) {
-		String header = "SimPathsMultiRun can run multiple sequential runs," +
+		String header = "SimPathsMultiRun can run multiple sequential runs, " +
 				"resetting the population to the start year and iterating from the start seed. " +
 				"It takes the following options:";
 		String footer = "When running with no display, `-g` must be set to `false`.";

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -89,7 +89,7 @@ public class SimPathsMultiRun extends MultiRun {
 			}
 
 			if (cmd.hasOption("g")) {
-				executeWithGui = true;
+				executeWithGui = Boolean.parseBoolean(cmd.getOptionValue("g"));
 			}
 
 			if (cmd.hasOption("c")) {

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -167,7 +167,7 @@ public class SimPathsMultiRun extends MultiRun {
 		} catch (ParseException e) {
 			System.err.println("Error parsing command line arguments: " + e.getMessage());
 			formatter.printHelp("SimPathsMultiRun", options);
-			return false;
+			System.exit(0);
 		}
 
 		return true;

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -54,6 +54,9 @@ public class SimPathsMultiRun extends MultiRun {
 
 		Options options = new Options();
 
+		Option helpOption = new Option("h", "Print help message");
+		options.addOption(helpOption);
+
 		Option maxRunsOption = new Option("n", true, "Maximum number of runs");
 		options.addOption(maxRunsOption);
 
@@ -84,6 +87,10 @@ public class SimPathsMultiRun extends MultiRun {
 		try {
 			CommandLine cmd = parser.parse(options, args);
 
+			if (cmd.hasOption("h")) {
+				printHelpMessage(formatter, options);
+				System.exit(0); // Exit without reporting an error
+			}
 			if (cmd.hasOption("n")) {
 				maxNumberOfRuns = Integer.parseInt(cmd.getOptionValue("n"));
 			}
@@ -140,7 +147,6 @@ public class SimPathsMultiRun extends MultiRun {
 		}
 
 
-
 		log.info("Starting run with seed = " + randomSeed);
 		
 		SimulationEngine engine = SimulationEngine.getInstance();
@@ -154,6 +160,14 @@ public class SimPathsMultiRun extends MultiRun {
 			new MultiRunFrame(experimentBuilder, "SimPaths MultiRun", maxNumberOfRuns);
 		else
 			experimentBuilder.start();
+	}
+
+	private static void printHelpMessage(HelpFormatter formatter, Options options) {
+		String header = "SimPathsMultiRun can run multiple sequential runs," +
+				"resetting the population to the start year and iterating from the start seed. " +
+				"It takes the following options:";
+		String footer = "When running with no display, `-g` must be set to `false`.";
+		formatter.printHelp("SimPathsMultiRun", header, options, footer, true);
 	}
 
 	@Override

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -77,32 +77,40 @@ public class SimPathsMultiRun extends MultiRun {
 
 		Options options = new Options();
 
-		Option helpOption = new Option("h", "Print help message");
-		options.addOption(helpOption);
 
-		Option maxRunsOption = new Option("n", true, "Maximum number of runs");
-		options.addOption(maxRunsOption);
-
-		Option guiOption = new Option("g", true, "Show GUI [true/false]");
-		options.addOption(guiOption);
-
-		Option seedOption = new Option("r", true, "Random seed");
-		options.addOption(seedOption);
+		Option popSizeOption = new Option("p", true, "Population size");
+		popSizeOption.setArgName("int");
+		options.addOption(popSizeOption);
 
 		Option startYearOption = new Option("s", true, "Start year");
+		startYearOption.setArgName("year");
 		options.addOption(startYearOption);
 
 		Option endYearOption = new Option("e", true, "End year");
+		endYearOption.setArgName("year");
 		options.addOption(endYearOption);
 
-		Option popSizeOption = new Option("p", true, "Population size");
-		options.addOption(popSizeOption);
+		Option maxRunsOption = new Option("n", true, "Maximum number of runs");
+		maxRunsOption.setArgName("int");
+		options.addOption(maxRunsOption);
+
+		Option seedOption = new Option("r", true, "Random seed");
+		seedOption.setArgName("int");
+		options.addOption(seedOption);
+
+		Option guiOption = new Option("g", true, "Show GUI");
+		guiOption.setArgName("true/false");
+		options.addOption(guiOption);
 
 		Option fileOption = new Option("f", "Output to file");
 		options.addOption(fileOption);
 
+		Option helpOption = new Option("h", "Print help message");
+		options.addOption(helpOption);
+
 		CommandLineParser parser = new DefaultParser();
 		HelpFormatter formatter = new HelpFormatter();
+		formatter.setOptionComparator(null);
 
 		try {
 			CommandLine cmd = parser.parse(options, args);

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -86,9 +86,6 @@ public class SimPathsMultiRun extends MultiRun {
 		Option guiOption = new Option("g", true, "Show GUI [true/false]");
 		options.addOption(guiOption);
 
-		Option countryOption = new Option("c", true, "Country");
-		options.addOption(countryOption);
-
 		Option seedOption = new Option("r", true, "Random seed");
 		options.addOption(seedOption);
 
@@ -120,10 +117,6 @@ public class SimPathsMultiRun extends MultiRun {
 
 			if (cmd.hasOption("g")) {
 				executeWithGui = Boolean.parseBoolean(cmd.getOptionValue("g"));
-			}
-
-			if (cmd.hasOption("c")) {
-				countryString = cmd.getOptionValue("c");
 			}
 
 			if (cmd.hasOption("r")) {

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -3,6 +3,7 @@ package simpaths.experiment;
 
 // import Java packages
 import org.apache.log4j.Level;
+import org.apache.commons.cli.*;
 import simpaths.data.Parameters;
 import simpaths.model.SimPathsModel;
 import microsim.data.MultiKeyCoefficientMap;
@@ -41,8 +42,6 @@ public class SimPathsMultiRun extends MultiRun {
 	 */
 	public static void main(String[] args) {
 
-
-
 		//Adjust the country and year to the value read from Excel, which is updated when the database is rebuilt. Otherwise it will set the country and year to the last one used to build the database
 		MultiKeyCoefficientMap lastDatabaseCountryAndYear = ExcelAssistant.loadCoefficientMap("input" + File.separator + Parameters.DatabaseCountryYearFilename + ".xlsx", "Data", 1, 1);
 		if (lastDatabaseCountryAndYear.keySet().stream().anyMatch(key -> key.toString().equals("MultiKey[IT]"))) {
@@ -53,43 +52,66 @@ public class SimPathsMultiRun extends MultiRun {
 		String valueYear = lastDatabaseCountryAndYear.getValue(Country.UK.getCountryFromNameString(countryString).toString()).toString();
 		startYear = Integer.parseInt(valueYear);
 
-		for (int i = 0; i < args.length; i++) {
-			if (args[i].equals("-n")){ // These options are for use from the command line
-				
-				try {
-					maxNumberOfRuns = Integer.parseInt(args[i + 1]);
-			    } catch (NumberFormatException e) {
-			        System.err.println("Argument " + args[i + 1] + " must be an integer reflecting the maximum number of runs.");
-			        System.exit(1);
-			    }
-				
-				i++;
+		Options options = new Options();
+
+		Option maxRunsOption = new Option("n", true, "Maximum number of runs");
+		options.addOption(maxRunsOption);
+
+		Option guiOption = new Option("g", true, "Show GUI [true/false]");
+		options.addOption(guiOption);
+
+		Option countryOption = new Option("c", true, "Country");
+		options.addOption(countryOption);
+
+		Option seedOption = new Option("r", true, "Random seed");
+		options.addOption(seedOption);
+
+		Option startYearOption = new Option("s", true, "Start year");
+		options.addOption(startYearOption);
+
+		Option endYearOption = new Option("e", true, "End year");
+		options.addOption(endYearOption);
+
+		Option popSizeOption = new Option("p", true, "Population size");
+		options.addOption(popSizeOption);
+
+		Option fileOption = new Option("f", "Output to file");
+		options.addOption(fileOption);
+
+		CommandLineParser parser = new DefaultParser();
+		HelpFormatter formatter = new HelpFormatter();
+
+		try {
+			CommandLine cmd = parser.parse(options, args);
+
+			if (cmd.hasOption("n")) {
+				maxNumberOfRuns = Integer.parseInt(cmd.getOptionValue("n"));
 			}
-			else if (args[i].equals("-g")){				//Set show GUI
-				executeWithGui = Boolean.parseBoolean(args[i + 1]);
-				i++;
+
+			if (cmd.hasOption("g")) {
+				executeWithGui = true;
 			}
-			else if (args[i].equals("-c")){				//Set country by arguments here
-				countryString = args[i+1];				
-				i++;
+
+			if (cmd.hasOption("c")) {
+				countryString = cmd.getOptionValue("c");
 			}
-			else if (args[i].equals("-r")){				//Set random seed
-				randomSeed = Long.parseLong(args[i+1]);
-				i++;
+
+			if (cmd.hasOption("r")) {
+				randomSeed = Long.parseLong(cmd.getOptionValue("r"));
 			}
-			else if (args[i].equals("-s")) {			//Set start year
-				startYear = Integer.parseInt(args[i + 1]);
-				i++;
+
+			if (cmd.hasOption("s")) {
+				startYear = Integer.parseInt(cmd.getOptionValue("s"));
 			}
-			else if (args[i].equals("-e")) {			//Set end year
-				endYear = Integer.parseInt(args[i + 1]);
-				i++;
+
+			if (cmd.hasOption("e")) {
+				endYear = Integer.parseInt(cmd.getOptionValue("e"));
 			}
-			else if (args[i].equals("-p")){				//Set population size
-				popSize = Integer.parseInt(args[i+1]);
-				i++;
+
+			if (cmd.hasOption("p")) {
+				popSize = Integer.parseInt(cmd.getOptionValue("p"));
 			}
-			else if (args[i].equals("-f")){             //Output to file
+			if (cmd.hasOption("f")) {
 				try {
 					File logDir = new File("output/logs");
 					if (!logDir.exists()) {
@@ -111,7 +133,13 @@ public class SimPathsMultiRun extends MultiRun {
 					throw new RuntimeException(e);
 				}
 			}
+		} catch (ParseException e) {
+			System.err.println("Error parsing command line arguments: " + e.getMessage());
+			formatter.printHelp("SimPathsMultiRun", options);
+			System.exit(1);
 		}
+
+
 
 		log.info("Starting run with seed = " + randomSeed);
 		

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -78,34 +78,34 @@ public class SimPathsMultiRun extends MultiRun {
 		Options options = new Options();
 
 
-		Option popSizeOption = new Option("p", true, "Population size");
+		Option popSizeOption = new Option("p", "popSize", true, "Population size");
 		popSizeOption.setArgName("int");
 		options.addOption(popSizeOption);
 
-		Option startYearOption = new Option("s", true, "Start year");
+		Option startYearOption = new Option("s", "startYear", true, "Start year");
 		startYearOption.setArgName("year");
 		options.addOption(startYearOption);
 
-		Option endYearOption = new Option("e", true, "End year");
+		Option endYearOption = new Option("e", "endYear",true, "End year");
 		endYearOption.setArgName("year");
 		options.addOption(endYearOption);
 
-		Option maxRunsOption = new Option("n", true, "Maximum number of runs");
+		Option maxRunsOption = new Option("n", "maxNumberOfRuns", true, "Maximum number of runs");
 		maxRunsOption.setArgName("int");
 		options.addOption(maxRunsOption);
 
-		Option seedOption = new Option("r", true, "Random seed");
+		Option seedOption = new Option("r", "randomSeed", true, "Random seed");
 		seedOption.setArgName("int");
 		options.addOption(seedOption);
 
-		Option guiOption = new Option("g", true, "Show GUI");
+		Option guiOption = new Option("g", "executeWithGui", true, "Show GUI");
 		guiOption.setArgName("true/false");
 		options.addOption(guiOption);
 
 		Option fileOption = new Option("f", "Output to file");
 		options.addOption(fileOption);
 
-		Option helpOption = new Option("h", "Print help message");
+		Option helpOption = new Option("h", "help", false, "Print this help message");
 		options.addOption(helpOption);
 
 		CommandLineParser parser = new DefaultParser();

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -167,7 +167,7 @@ public class SimPathsMultiRun extends MultiRun {
 		} catch (ParseException e) {
 			System.err.println("Error parsing command line arguments: " + e.getMessage());
 			formatter.printHelp("SimPathsMultiRun", options);
-			System.exit(0);
+			System.exit(1);
 		}
 
 		return true;

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -52,6 +52,29 @@ public class SimPathsMultiRun extends MultiRun {
 		String valueYear = lastDatabaseCountryAndYear.getValue(Country.UK.getCountryFromNameString(countryString).toString()).toString();
 		startYear = Integer.parseInt(valueYear);
 
+		// Parse command line arguments to override defaults
+		if (!parseCommandLineArgs(args)) {
+			// If parseCommandLineArgs returns false (indicating help option is provided), exit main
+			return;
+		}
+
+		log.info("Starting run with seed = " + randomSeed);
+		
+		SimulationEngine engine = SimulationEngine.getInstance();
+		
+		SimPathsMultiRun experimentBuilder = new SimPathsMultiRun();
+//		engine.setBuilderClass(SimPathsMultiRun.class);			//This works but is deprecated
+		engine.setExperimentBuilder(experimentBuilder);					//This replaces the above line... but does it work?
+		engine.setup();													//Do we need this?  Worked fine without it...
+
+		if (executeWithGui)
+			new MultiRunFrame(experimentBuilder, "SimPaths MultiRun", maxNumberOfRuns);
+		else
+			experimentBuilder.start();
+	}
+
+	private static boolean parseCommandLineArgs(String[] args) {
+
 		Options options = new Options();
 
 		Option helpOption = new Option("h", "Print help message");
@@ -89,7 +112,7 @@ public class SimPathsMultiRun extends MultiRun {
 
 			if (cmd.hasOption("h")) {
 				printHelpMessage(formatter, options);
-				return; // Exit without reporting an error
+				return false; // Exit without reporting an error
 			}
 			if (cmd.hasOption("n")) {
 				maxNumberOfRuns = Integer.parseInt(cmd.getOptionValue("n"));
@@ -143,23 +166,10 @@ public class SimPathsMultiRun extends MultiRun {
 		} catch (ParseException e) {
 			System.err.println("Error parsing command line arguments: " + e.getMessage());
 			formatter.printHelp("SimPathsMultiRun", options);
-			System.exit(1);
+			return false;
 		}
 
-
-		log.info("Starting run with seed = " + randomSeed);
-		
-		SimulationEngine engine = SimulationEngine.getInstance();
-		
-		SimPathsMultiRun experimentBuilder = new SimPathsMultiRun();
-//		engine.setBuilderClass(SimPathsMultiRun.class);			//This works but is deprecated
-		engine.setExperimentBuilder(experimentBuilder);					//This replaces the above line... but does it work?
-		engine.setup();													//Do we need this?  Worked fine without it...
-
-		if (executeWithGui)
-			new MultiRunFrame(experimentBuilder, "SimPaths MultiRun", maxNumberOfRuns);
-		else
-			experimentBuilder.start();
+		return true;
 	}
 
 	private static void printHelpMessage(HelpFormatter formatter, Options options) {

--- a/src/main/java/simpaths/experiment/SimPathsStart.java
+++ b/src/main/java/simpaths/experiment/SimPathsStart.java
@@ -78,6 +78,9 @@ public class SimPathsStart implements ExperimentBuilder {
 
 		Options options = new Options();
 
+		Option helpOption = new Option("h", "Print help message");
+		options.addOption(helpOption);
+
 		Option guiOption = new Option("g", true, "Show GUI [true/false]");
 		options.addOption(guiOption);
 
@@ -95,6 +98,11 @@ public class SimPathsStart implements ExperimentBuilder {
 
 		try {
 			CommandLine cmd = parser.parse(options, args);
+
+			if (cmd.hasOption("h")) {
+				printHelpMessage(formatter, options);
+				System.exit(0); // Exit without reporting an error
+			}
 
 			if (cmd.hasOption("g")) {
 				showGui = Boolean.parseBoolean(cmd.getOptionValue("g"));
@@ -150,6 +158,15 @@ public class SimPathsStart implements ExperimentBuilder {
 		SimPathsStart experimentBuilder = new SimPathsStart();
 		engine.setExperimentBuilder(experimentBuilder);
 		engine.setup();
+	}
+
+	private static void printHelpMessage(HelpFormatter formatter, Options options) {
+		String header = "SimPathsStart will start the SimPaths run. " +
+				"When using the argument `Setup`, this will create the population database " +
+				"and exit before starting the first run. " +
+				"It takes the following options:";
+		String footer = "When running with no display, `-g` must be set to `false`.";
+		formatter.printHelp("SimPathsStart", header, options, footer, true);
 	}
 
 

--- a/src/main/java/simpaths/experiment/SimPathsStart.java
+++ b/src/main/java/simpaths/experiment/SimPathsStart.java
@@ -167,7 +167,7 @@ public class SimPathsStart implements ExperimentBuilder {
 		} catch (ParseException | IllegalArgumentException e) {
 			System.err.println("Error parsing command line arguments: " + e.getMessage());
 			formatter.printHelp("SimPathsStart", options);
-			System.exit(0);
+			System.exit(1);
 		}
 
 		return true;

--- a/src/main/java/simpaths/experiment/SimPathsStart.java
+++ b/src/main/java/simpaths/experiment/SimPathsStart.java
@@ -167,7 +167,7 @@ public class SimPathsStart implements ExperimentBuilder {
 		} catch (ParseException | IllegalArgumentException e) {
 			System.err.println("Error parsing command line arguments: " + e.getMessage());
 			formatter.printHelp("SimPathsStart", options);
-			return false;
+			System.exit(0);
 		}
 
 		return true;

--- a/src/main/java/simpaths/experiment/SimPathsStart.java
+++ b/src/main/java/simpaths/experiment/SimPathsStart.java
@@ -101,7 +101,7 @@ public class SimPathsStart implements ExperimentBuilder {
 
 			if (cmd.hasOption("h")) {
 				printHelpMessage(formatter, options);
-				System.exit(0); // Exit without reporting an error
+				return; // Exit without reporting an error
 			}
 
 			if (cmd.hasOption("g")) {

--- a/src/main/java/simpaths/experiment/SimPathsStart.java
+++ b/src/main/java/simpaths/experiment/SimPathsStart.java
@@ -76,53 +76,9 @@ public class SimPathsStart implements ExperimentBuilder {
 	public static void main(String[] args) {
 
 
-		Options options = new Options();
-
-		Option helpOption = new Option("h", "Print help message");
-		options.addOption(helpOption);
-
-		Option guiOption = new Option("g", true, "Show GUI [true/false]");
-		options.addOption(guiOption);
-
-		Option countryOption = new Option("c", true, "Country");
-		options.addOption(countryOption);
-
-		Option startYearOption = new Option("s", true, "Start year");
-		options.addOption(startYearOption);
-
-		Option setupOption = new Option("Setup", "Setup only");
-		options.addOption(setupOption);
-
-		CommandLineParser parser = new DefaultParser();
-		HelpFormatter formatter = new HelpFormatter();
-
-		try {
-			CommandLine cmd = parser.parse(options, args);
-
-			if (cmd.hasOption("h")) {
-				printHelpMessage(formatter, options);
-				return; // Exit without reporting an error
-			}
-
-			if (cmd.hasOption("g")) {
-				showGui = Boolean.parseBoolean(cmd.getOptionValue("g"));
-			}
-
-			if (cmd.hasOption("c")) {
-				country = Country.valueOf(cmd.getOptionValue("c"));
-			}
-
-			if (cmd.hasOption("s")) {
-				startYear = Integer.parseInt(cmd.getOptionValue("s"));
-			}
-
-			if (cmd.hasOption("Setup")) {
-				setupOnly = true;
-			}
-		} catch (ParseException | IllegalArgumentException e) {
-			System.err.println("Error parsing command line arguments: " + e.getMessage());
-			formatter.printHelp("SimPathsStart", options);
-			System.exit(1);
+		if (!parseCommandLineArgs(args)) {
+			// If parseCommandLineArgs returns false (indicating help option is provided), exit main
+			return;
 		}
 
 		if (showGui) {
@@ -158,6 +114,59 @@ public class SimPathsStart implements ExperimentBuilder {
 		SimPathsStart experimentBuilder = new SimPathsStart();
 		engine.setExperimentBuilder(experimentBuilder);
 		engine.setup();
+	}
+
+	private static boolean parseCommandLineArgs(String[] args) {
+		Options options = new Options();
+
+		Option helpOption = new Option("h", "Print help message");
+		options.addOption(helpOption);
+
+		Option guiOption = new Option("g", true, "Show GUI [true/false]");
+		options.addOption(guiOption);
+
+		Option countryOption = new Option("c", true, "Country");
+		options.addOption(countryOption);
+
+		Option startYearOption = new Option("s", true, "Start year");
+		options.addOption(startYearOption);
+
+		Option setupOption = new Option("Setup", "Setup only");
+		options.addOption(setupOption);
+
+		CommandLineParser parser = new DefaultParser();
+		HelpFormatter formatter = new HelpFormatter();
+
+		try {
+			CommandLine cmd = parser.parse(options, args);
+
+			if (cmd.hasOption("h")) {
+				printHelpMessage(formatter, options);
+				return false; // Exit without reporting an error
+			}
+
+			if (cmd.hasOption("g")) {
+				showGui = Boolean.parseBoolean(cmd.getOptionValue("g"));
+			}
+
+			if (cmd.hasOption("c")) {
+				country = Country.valueOf(cmd.getOptionValue("c"));
+			}
+
+			if (cmd.hasOption("s")) {
+				startYear = Integer.parseInt(cmd.getOptionValue("s"));
+			}
+
+			if (cmd.hasOption("Setup")) {
+				setupOnly = true;
+			}
+		} catch (ParseException | IllegalArgumentException e) {
+			System.err.println("Error parsing command line arguments: " + e.getMessage());
+			formatter.printHelp("SimPathsStart", options);
+			return false;
+		}
+
+		return true;
 	}
 
 	private static void printHelpMessage(HelpFormatter formatter, Options options) {

--- a/src/main/java/simpaths/experiment/SimPathsStart.java
+++ b/src/main/java/simpaths/experiment/SimPathsStart.java
@@ -123,7 +123,7 @@ public class SimPathsStart implements ExperimentBuilder {
 		countryOption.setArgName("UK/IT");
 		options.addOption(countryOption);
 
-		Option startYearOption = new Option("y", true, "Start year");
+		Option startYearOption = new Option("s", true, "Start year");
 		startYearOption.setArgName("year");
 		options.addOption(startYearOption);
 
@@ -157,8 +157,8 @@ public class SimPathsStart implements ExperimentBuilder {
 				country = Country.valueOf(cmd.getOptionValue("c"));
 			}
 
-			if (cmd.hasOption("y")) {
-				startYear = Integer.parseInt(cmd.getOptionValue("y"));
+			if (cmd.hasOption("s")) {
+				startYear = Integer.parseInt(cmd.getOptionValue("s"));
 			}
 
 			if (cmd.hasOption("Setup")) {

--- a/src/main/java/simpaths/experiment/SimPathsStart.java
+++ b/src/main/java/simpaths/experiment/SimPathsStart.java
@@ -123,7 +123,7 @@ public class SimPathsStart implements ExperimentBuilder {
 		countryOption.setArgName("UK/IT");
 		options.addOption(countryOption);
 
-		Option startYearOption = new Option("s", true, "Start year");
+		Option startYearOption = new Option("y", true, "Start year");
 		startYearOption.setArgName("year");
 		options.addOption(startYearOption);
 
@@ -157,8 +157,8 @@ public class SimPathsStart implements ExperimentBuilder {
 				country = Country.valueOf(cmd.getOptionValue("c"));
 			}
 
-			if (cmd.hasOption("s")) {
-				startYear = Integer.parseInt(cmd.getOptionValue("s"));
+			if (cmd.hasOption("y")) {
+				startYear = Integer.parseInt(cmd.getOptionValue("y"));
 			}
 
 			if (cmd.hasOption("Setup")) {

--- a/src/main/java/simpaths/experiment/SimPathsStart.java
+++ b/src/main/java/simpaths/experiment/SimPathsStart.java
@@ -119,22 +119,22 @@ public class SimPathsStart implements ExperimentBuilder {
 	private static boolean parseCommandLineArgs(String[] args) {
 		Options options = new Options();
 
-		Option countryOption = new Option("c", true, "Country");
-		countryOption.setArgName("UK/IT");
+		Option countryOption = new Option("c", "country", true, "Country (by country code CC, e.g. 'UK'/'IT')");
+		countryOption.setArgName("CC");
 		options.addOption(countryOption);
 
-		Option startYearOption = new Option("s", true, "Start year");
+		Option startYearOption = new Option("s", "startYear", true, "Start year");
 		startYearOption.setArgName("year");
 		options.addOption(startYearOption);
 
 		Option setupOption = new Option("Setup", "Setup only");
 		options.addOption(setupOption);
 
-		Option guiOption = new Option("g", true, "Show GUI [true/false]");
+		Option guiOption = new Option("g", "showGui", true, "Show GUI");
 		guiOption.setArgName("true/false");
 		options.addOption(guiOption);
 
-		Option helpOption = new Option("h", "Print help message");
+		Option helpOption = new Option("h", "help", false, "Print help message");
 		options.addOption(helpOption);
 
 		CommandLineParser parser = new DefaultParser();

--- a/src/main/java/simpaths/experiment/SimPathsStart.java
+++ b/src/main/java/simpaths/experiment/SimPathsStart.java
@@ -3,6 +3,7 @@ package simpaths.experiment;
 
 // import Java packages
 import java.awt.Dimension;
+import org.apache.commons.cli.*;
 import java.awt.Toolkit;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -75,22 +76,45 @@ public class SimPathsStart implements ExperimentBuilder {
 	public static void main(String[] args) {
 
 
-		for (int i = 0; i < args.length; i++) {
-			if (args[i].equals("-g")) {                //Set show GUI
-				showGui = Boolean.parseBoolean(args[i + 1]);
-				i++;
+		Options options = new Options();
+
+		Option guiOption = new Option("g", true, "Show GUI [true/false]");
+		options.addOption(guiOption);
+
+		Option countryOption = new Option("c", true, "Country");
+		options.addOption(countryOption);
+
+		Option startYearOption = new Option("s", true, "Start year");
+		options.addOption(startYearOption);
+
+		Option setupOption = new Option("Setup", "Setup only");
+		options.addOption(setupOption);
+
+		CommandLineParser parser = new DefaultParser();
+		HelpFormatter formatter = new HelpFormatter();
+
+		try {
+			CommandLine cmd = parser.parse(options, args);
+
+			if (cmd.hasOption("g")) {
+				showGui = Boolean.parseBoolean(cmd.getOptionValue("g"));
 			}
-			else if (args[i].equals("-c")) {
-				country = Country.valueOf(args[i + 1]);
-				i++;
+
+			if (cmd.hasOption("c")) {
+				country = Country.valueOf(cmd.getOptionValue("c"));
 			}
-			else if (args[i].equals("-s")) {
-				startYear = Integer.parseInt(args[i + 1]);
-				i++;
+
+			if (cmd.hasOption("s")) {
+				startYear = Integer.parseInt(cmd.getOptionValue("s"));
 			}
-			else if (args[i].equals("-Setup")) {
+
+			if (cmd.hasOption("Setup")) {
 				setupOnly = true;
 			}
+		} catch (ParseException | IllegalArgumentException e) {
+			System.err.println("Error parsing command line arguments: " + e.getMessage());
+			formatter.printHelp("SimPathsStart", options);
+			System.exit(1);
 		}
 
 		if (showGui) {

--- a/src/main/java/simpaths/experiment/SimPathsStart.java
+++ b/src/main/java/simpaths/experiment/SimPathsStart.java
@@ -119,23 +119,27 @@ public class SimPathsStart implements ExperimentBuilder {
 	private static boolean parseCommandLineArgs(String[] args) {
 		Options options = new Options();
 
-		Option helpOption = new Option("h", "Print help message");
-		options.addOption(helpOption);
-
-		Option guiOption = new Option("g", true, "Show GUI [true/false]");
-		options.addOption(guiOption);
-
 		Option countryOption = new Option("c", true, "Country");
+		countryOption.setArgName("UK/IT");
 		options.addOption(countryOption);
 
 		Option startYearOption = new Option("s", true, "Start year");
+		startYearOption.setArgName("year");
 		options.addOption(startYearOption);
 
 		Option setupOption = new Option("Setup", "Setup only");
 		options.addOption(setupOption);
 
+		Option guiOption = new Option("g", true, "Show GUI [true/false]");
+		guiOption.setArgName("true/false");
+		options.addOption(guiOption);
+
+		Option helpOption = new Option("h", "Print help message");
+		options.addOption(helpOption);
+
 		CommandLineParser parser = new DefaultParser();
 		HelpFormatter formatter = new HelpFormatter();
+		formatter.setOptionComparator(null);
 
 		try {
 			CommandLine cmd = parser.parse(options, args);

--- a/src/test/java/simpaths/experiment/SimPathsMultiRunTest.java
+++ b/src/test/java/simpaths/experiment/SimPathsMultiRunTest.java
@@ -10,18 +10,18 @@ import java.io.PrintStream;
 public class SimPathsMultiRunTest {
 
     private static final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
-    private static final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+//    private static final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
 
     @BeforeAll
     public static void setUpStreams() {
         System.setOut(new PrintStream(outContent));
-        System.setErr(new PrintStream(errContent));
+//        System.setErr(new PrintStream(errContent));
     }
 
     @BeforeEach
     public void resetStreams() {
         outContent.reset();
-        errContent.reset();
+//        errContent.reset();
     }
 
     @Test
@@ -29,10 +29,10 @@ public class SimPathsMultiRunTest {
         String[] args = {"-h"};
         SimPathsMultiRun.main(args);
 
-        String expectedHelpText = "SimPathsMultiRun can run multiple sequential runs, resetting the population to the start year and iterating from the start seed. It takes the following options:";
+        String expectedHelpText = "SimPathsMultiRun can run multiple sequential runs";
 
         assertTrue(outContent.toString().contains(expectedHelpText));
-        assertEquals("", errContent.toString().trim());
+//        assertEquals("", errContent.toString().trim());
     }
 
     // Add more test methods for other scenarios as needed

--- a/src/test/java/simpaths/experiment/SimPathsMultiRunTest.java
+++ b/src/test/java/simpaths/experiment/SimPathsMultiRunTest.java
@@ -1,0 +1,2 @@
+package simpaths.experiment;public class SimPathsMultiRunTest {
+}

--- a/src/test/java/simpaths/experiment/SimPathsStartTest.java
+++ b/src/test/java/simpaths/experiment/SimPathsStartTest.java
@@ -1,4 +1,5 @@
 package simpaths.experiment;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -7,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
-public class SimPathsMultiRunTest {
+public class SimPathsStartTest {
 
     private static final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
     private static final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
@@ -21,15 +22,26 @@ public class SimPathsMultiRunTest {
     @BeforeEach
     public void resetStreams() {
         outContent.reset();
-        errContent.reset();
+//        errContent.reset();
     }
 
     @Test
-    public void testSimPathsMultiRunHelpOption() {
+    public void testSimPathsStartHelpOption() {
         String[] args = {"-h"};
-        SimPathsMultiRun.main(args);
+        SimPathsStart.main(args);
 
-        String expectedHelpText = "SimPathsMultiRun can run multiple sequential runs, resetting the population to the start year and iterating from the start seed. It takes the following options:";
+        String expectedHelpText = "SimPathsStart will start the SimPaths run";
+
+        assertTrue(outContent.toString().contains(expectedHelpText));
+        assertEquals("", errContent.toString().trim());
+    }
+
+    @Test
+    public void testSimPathsStartHelpOptionWithOtherArguments() {
+        String[] args = {"-g", "false", "-h", "-c", "UK"};
+        SimPathsStart.main(args);
+
+        String expectedHelpText = "SimPathsStart will start the SimPaths run";
 
         assertTrue(outContent.toString().contains(expectedHelpText));
         assertEquals("", errContent.toString().trim());


### PR DESCRIPTION
This is an experimental tweak to the argument parsing I had put in before. Now it more safely parses arguments (I hope) and can provide a help output on invalid arguments or `-h` flag:

```
$ java -jar singlerun.jar -h
usage: SimPathsStart [-c <arg>] [-g <arg>] [-h] [-s <arg>] [-Setup]
SimPathsStart will start the SimPaths run. When using the argument
`Setup`, this will create the population database and exit before starting
the first run. It takes the following options:
 -c <arg>   Country
 -g <arg>   Show GUI [true/false]
 -h         Print help message
 -s <arg>   Start year
 -Setup     Setup only
When running with no display, `-g` must be set to `false`.
```
and
```
$ java -jar multirun.jar -h
usage: SimPathsMultiRun [-e <arg>] [-f] [-g <arg>] [-h] [-n <arg>] [-p
       <arg>] [-r <arg>] [-s <arg>]
SimPathsMultiRun can run multiple sequential runs, resetting the
population to the start year and iterating from the start seed. It takes
the following options:
 -e <arg>   End year
 -f         Output to file
 -g <arg>   Show GUI [true/false]
 -h         Print help message
 -n <arg>   Maximum number of runs
 -p <arg>   Population size
 -r <arg>   Random seed
 -s <arg>   Start year
When running with no display, `-g` must be set to `false`.
```

Added two test files to detect content of help outputs when running each class.