### PR TITLE
add badge to readme.md for actions run

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build and run SimPaths](https://github.com/centreformicrosimulation/SimPaths/actions/workflows/SimPathsBuild.yml/badge.svg)](https://github.com/centreformicrosimulation/SimPaths/actions/workflows/SimPathsBuild.yml)
+
 # SimPaths
 
 by Matteo Richiardi, Patryk Bronka, Justin van de Ven

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build and run SimPaths](https://github.com/centreformicrosimulation/SimPaths/actions/workflows/SimPathsBuild.yml/badge.svg)](https://github.com/centreformicrosimulation/SimPaths/actions/workflows/SimPathsBuild.yml)
+[![Build and run SimPaths](https://github.com/centreformicrosimulation/SimPaths/workflows/Build%20and%20run%20SimPaths/badge.svg)](https://github.com/centreformicrosimulation/SimPaths/actions/workflows/SimPathsBuild.yml)
 
 # SimPaths
 


### PR DESCRIPTION
A tiny tweak for a small additional feature? Very incidental but creates a nice badge 😁 

[![Build and run SimPaths](https://github.com/centreformicrosimulation/SimPaths/actions/workflows/SimPathsBuild.yml/badge.svg)](https://github.com/centreformicrosimulation/SimPaths/actions/workflows/SimPathsBuild.yml)