### PR TITLE
Experimental/config parsing

### DIFF
--- a/.github/workflows/SimPathsBuild.yml
+++ b/.github/workflows/SimPathsBuild.yml
@@ -56,4 +56,4 @@ jobs:
       run: java -jar singlerun.jar -c UK -s 2017 -Setup -g false
 
     - name: Do one run
-      run: java -jar multirun.jar -p 50000 -s 2017 -e 2020 -r 100 -n 2 -g false
+      run: java -jar multirun.jar -p 20000 -s 2017 -e 2020 -r 100 -n 2 -g false

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,11 @@
+maxNumberOfRuns: 5
+executeWithGui: false
+randomSeed: 12345
+startYear: 2020
+endYear: 2025
+popSize: 75000
+
+model_args:
+    alignEducation: true
+    sIndexAlpha: 2.1
+    enableIntertemporalOptimisations: true

--- a/config.yml
+++ b/config.yml
@@ -40,3 +40,15 @@ model_args:
 #    responsesToDisability: false
 #    minAgeForPoorHealth: 50
 #    responsesToRegion: false
+
+collector_args:
+#    calculateGiniCoefficients: false
+#    exportToDatabase: false
+#    exportToCSV: true
+#    persistStatistics: true
+#    persistStatistics2: true
+#    persistPersons: false
+#    persistBenefitUnits: false
+#    persistHouseholds: false
+#    dataDumpStartTime: 0L
+#    dataDumpTimePeriod: 1.0

--- a/config.yml
+++ b/config.yml
@@ -10,5 +10,5 @@ popSize: 75000
 
 # For arguments to pass to the SimPathsModel itself:
 model_args:
-    labourMarketCovid19On: false
-    enableIntertemporalOptimisations: false
+#    labourMarketCovid19On: false
+#    enableIntertemporalOptimisations: false

--- a/config.yml
+++ b/config.yml
@@ -9,6 +9,34 @@ endYear: 2025
 popSize: 75000
 
 # For arguments to pass to the SimPathsModel itself:
+# Current model defaults can be overridden by uncommenting/changing
 model_args:
+#    maxAge: 130
+#    fixTimeTrend: true
+#    timeTrendStopsIn: 2017
+#    fixRandomSeed: true
+#    sIndexTimeWindow: 5
+#    sIndexAlpha: 2
+#    sIndexDelta: 0
+#    savingRate: 0
+#    initialisePotentialEarningsFromDatabase: true
+#    useWeights: false
+#    useSBAMMatching:
+#    projectMortality: true
+#    alignFertility: true
 #    labourMarketCovid19On: false
+#    projectFormalChildcare: true
+#    donorPoolAveraging: true
+#    projectSocialCare: false
 #    enableIntertemporalOptimisations: false
+#    useSavedBehaviour: false
+#    readGrid: "laptop serial"
+#    saveBehaviour: true
+#    employmentOptionsOfPrincipalWorker: 3
+#    employmentOptionsOfSecondaryWorker: 3
+#    responsesToEducation: true
+#    responsesToRetirement: false
+#    responsesToHealth: true
+#    responsesToDisability: false
+#    minAgeForPoorHealth: 50
+#    responsesToRegion: false

--- a/config.yml
+++ b/config.yml
@@ -1,11 +1,14 @@
+# This file can be used to override defaults for multirun arguments.
+# These will be overridden by command-line arguments
+
 maxNumberOfRuns: 5
 executeWithGui: false
 randomSeed: 12345
-startYear: 2020
+startYear: 2018
 endYear: 2025
 popSize: 75000
 
+# For arguments to pass to the SimPathsModel itself:
 model_args:
-    alignEducation: true
-    sIndexAlpha: 2.1
-    enableIntertemporalOptimisations: true
+    labourMarketCovid19On: false
+    enableIntertemporalOptimisations: false

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,11 @@
 			<version>1.4</version> <!-- Use the latest version available -->
 		</dependency>
 		<dependency>
+			<groupId>org.yaml</groupId>
+			<artifactId>snakeyaml</artifactId>
+			<version>1.29</version> <!-- Use the latest version available -->
+		</dependency>
+		<dependency>
 			<groupId>com.github.jasmineRepo</groupId>
 			<artifactId>JAS-mine-core</artifactId>
 			<version>4.3.6</version>

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -47,6 +47,8 @@ public class SimPathsMultiRun extends MultiRun {
 
 	private static Map<String, Object> collector_args;
 
+	public static String configFile = "config.yml";  // Default config file name
+
 	/**
 	 *
 	 * 	MAIN PROGRAM ENTRY FOR MULTI-SIMULATION
@@ -64,7 +66,10 @@ public class SimPathsMultiRun extends MultiRun {
 		String valueYear = lastDatabaseCountryAndYear.getValue(Country.UK.getCountryFromNameString(countryString).toString()).toString();
 		startYear = Integer.parseInt(valueYear);
 
-		parseYamlConfig(args);
+		if (!parseYamlConfig(args)) {
+			// if parseYamlConfig returns false (indicating bad filename passed), exit main
+			return;
+		}
 
 		// Parse command line arguments to override defaults
 		if (!parseCommandLineArgs(args)) {
@@ -199,13 +204,15 @@ public class SimPathsMultiRun extends MultiRun {
 		formatter.printHelp("SimPathsMultiRun", header, options, footer, true);
 	}
 
-	private static void parseYamlConfig(String[] args) {
-		String configFile = "config.yml";  // Default config file name
+	private static boolean parseYamlConfig(String[] args) {
+
+		boolean custom_config = false;
 
 		// Check if an alternative config file is specified in the command line
 		for (int i = 0; i < args.length - 1; i++) {
 			if (args[i].equals("-config")) {
 				configFile = args[i + 1];
+				custom_config = true;
 				break;
 			}
 		}
@@ -253,9 +260,13 @@ public class SimPathsMultiRun extends MultiRun {
 			}
 
 		} catch (FileNotFoundException e) {
-			// Config file not found, continue with defaults
-			System.out.println("Config file " + configFile + " not found; continuing with default/cli parameters.");
+			// Config file specified but not found, continue with defaults
+			if (custom_config) {
+				System.err.println("Config file " + configFile + " not found; please supply a valid config file.");
+				return false;
+			}
 		}
+		return true;
 	}
 
 	public static void updateParameters(Object object, Map<String, Object> model_args) {

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -253,14 +253,14 @@ public class SimPathsMultiRun extends MultiRun {
 		}
 	}
 
-	public static void updateModelParameters(SimPathsModel model, Map<String, Object> model_args) {
+	public static void updateParameters(Object object, Map<String, Object> model_args) {
 
 		for (Map.Entry<String, Object> entry : model_args.entrySet()) {
 			String key = entry.getKey();
 			Object value = entry.getValue();
 
 			try {
-				Field field = SimPathsModel.class.getDeclaredField(key);
+				Field field = object.getClass().getDeclaredField(key);
 				field.setAccessible(true);
 
 				// Determine the field type
@@ -270,35 +270,7 @@ public class SimPathsMultiRun extends MultiRun {
 				Object convertedValue = convertToType(value, fieldType);
 
 				// Set the field value
-				field.set(model, convertedValue);
-
-				field.setAccessible(false);
-			} catch (NoSuchFieldException | IllegalAccessException e) {
-				// Handle exceptions if the field is not found or inaccessible
-				e.printStackTrace();
-			}
-		}
-
-	}
-
-	public static void updateCollectorParameters(SimPathsCollector collector, Map<String, Object> model_args) {
-
-		for (Map.Entry<String, Object> entry : model_args.entrySet()) {
-			String key = entry.getKey();
-			Object value = entry.getValue();
-
-			try {
-				Field field = SimPathsCollector.class.getDeclaredField(key);
-				field.setAccessible(true);
-
-				// Determine the field type
-				Class<?> fieldType = field.getType();
-
-				// Convert the YAML value to the field type
-				Object convertedValue = convertToType(value, fieldType);
-
-				// Set the field value
-				field.set(collector, convertedValue);
+				field.set(object, convertedValue);
 
 				field.setAccessible(false);
 			} catch (NoSuchFieldException | IllegalAccessException e) {
@@ -339,12 +311,12 @@ public class SimPathsMultiRun extends MultiRun {
 		model.setPopSize(popSize);
 		model.setRandomSeedIfFixed(randomSeed);
 
-		if (model_args != null) updateModelParameters(model, model_args);
+		if (model_args != null) updateParameters(model, model_args);
 
 		engine.addSimulationManager(model);
 
 		SimPathsCollector collector = new SimPathsCollector(model);
-		if (collector_args != null) updateCollectorParameters(collector, collector_args);
+		if (collector_args != null) updateParameters(collector, collector_args);
 		engine.addSimulationManager(collector);
 
 		model.setCollector(collector);

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -62,13 +62,13 @@ public class SimPathsMultiRun extends MultiRun {
 		String valueYear = lastDatabaseCountryAndYear.getValue(Country.UK.getCountryFromNameString(countryString).toString()).toString();
 		startYear = Integer.parseInt(valueYear);
 
+		parseYamlConfig(args);
+
 		// Parse command line arguments to override defaults
 		if (!parseCommandLineArgs(args)) {
 			// If parseCommandLineArgs returns false (indicating help option is provided), exit main
 			return;
 		}
-
-		parseYamlConfig(args);
 
 		log.info("Starting run with seed = " + randomSeed);
 		

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -254,6 +254,7 @@ public class SimPathsMultiRun extends MultiRun {
 
 		} catch (FileNotFoundException e) {
 			// Config file not found, continue with defaults
+			System.out.println("Config file " + configFile + " not found; continuing with default/cli parameters.");
 		}
 	}
 

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -116,6 +116,10 @@ public class SimPathsMultiRun extends MultiRun {
 		guiOption.setArgName("true/false");
 		options.addOption(guiOption);
 
+		Option configOption = new Option("config", true, "Specify custom config file (default: config.yml)");
+		configOption.setArgName("file");
+		options.addOption(configOption);
+
 		Option fileOption = new Option("f", "Output to file");
 		options.addOption(fileOption);
 

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -304,7 +304,7 @@ public class SimPathsMultiRun extends MultiRun {
 		model.setPopSize(popSize);
 		model.setRandomSeedIfFixed(randomSeed);
 
-		updateModelParameters(model, model_args);
+		if (model_args != null) updateModelParameters(model, model_args);
 
 		engine.addSimulationManager(model);
 		

--- a/src/test/java/simpaths/experiment/SimPathsMultiRunTest.java
+++ b/src/test/java/simpaths/experiment/SimPathsMultiRunTest.java
@@ -21,7 +21,7 @@ public class SimPathsMultiRunTest {
     @BeforeEach
     public void resetStreams() {
         outContent.reset();
-//        errContent.reset();
+        errContent.reset();
     }
 
     @Test

--- a/src/test/java/simpaths/experiment/SimPathsMultiRunTest.java
+++ b/src/test/java/simpaths/experiment/SimPathsMultiRunTest.java
@@ -10,12 +10,12 @@ import java.io.PrintStream;
 public class SimPathsMultiRunTest {
 
     private static final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
-//    private static final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+    private static final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
 
     @BeforeAll
     public static void setUpStreams() {
         System.setOut(new PrintStream(outContent));
-//        System.setErr(new PrintStream(errContent));
+        System.setErr(new PrintStream(errContent));
     }
 
     @BeforeEach
@@ -33,6 +33,15 @@ public class SimPathsMultiRunTest {
 
         assertTrue(outContent.toString().contains(expectedHelpText));
 //        assertEquals("", errContent.toString().trim());
+    }
+
+    @Test
+    public void testBadConfigFile() {
+        String[] args = {"-config", "wrong.yml"};
+        SimPathsMultiRun.main(args);
+
+        String expectedErrorText = "Config file wrong.yml not found; please supply a valid config file";
+        assertTrue(errContent.toString().contains(expectedErrorText));
     }
 
     // Add more test methods for other scenarios as needed


### PR DESCRIPTION
This is a *highly* experimental branch for now. It should allow a user to provide a `config.yml` file which reliably, recordably, repeatably passes the same arguments to SimPathsMultiRun and internal SimPathsModel runs. Can handle all parameters shown in the SimPaths GUI and allow these to be specified external to the java code. Ideally could mean that any scenario/run could be carried out from a static released version of SimPaths. Will tidy and follow up with more explanation.