### PR TITLE
Don't automatically rebuild EUROMODpolicySchedule file and check for valid file.

### DIFF
--- a/.github/workflows/SimPathsBuild.yml
+++ b/.github/workflows/SimPathsBuild.yml
@@ -59,7 +59,7 @@ jobs:
       id: check_file
       uses: thebinaryfelix/check-file-existence-action@1.0.0
       with:
-        files: 'input/impoot.mv.db'
+        files: 'input/input.mv.db'
 
     - name: Files exist
       if: steps.check_files.outputs.exists == 'false'

--- a/.github/workflows/SimPathsBuild.yml
+++ b/.github/workflows/SimPathsBuild.yml
@@ -53,7 +53,7 @@ jobs:
         path: .
 
     - name: Setup run
-      run: java -jar singlerun.jar -c UK -s 2017 -Setup -g false
+      run: java -jar singlerun.jar -c UK -s 2017 -Setup -g false --rewrite-policy-schedule
 
     - name: Do one run
       run: java -jar multirun.jar -p 50000 -s 2017 -e 2020 -r 100 -n 2 -g false

--- a/.github/workflows/SimPathsBuild.yml
+++ b/.github/workflows/SimPathsBuild.yml
@@ -55,5 +55,15 @@ jobs:
     - name: Setup run
       run: java -jar singlerun.jar -c UK -s 2017 -Setup -g false --rewrite-policy-schedule
 
+    - name: Check input db exists
+      id: check_file
+      uses: thebinaryfelix/check-file-existence-action@v1
+      with:
+        files: 'input/impoot.mv.db'
+
+    - name: Files exist
+      if: steps.check_files.outputs.exists == 'false'
+      run: exit 1
+
     - name: Do one run
       run: java -jar multirun.jar -p 50000 -s 2017 -e 2020 -r 100 -n 2 -g false

--- a/.github/workflows/SimPathsBuild.yml
+++ b/.github/workflows/SimPathsBuild.yml
@@ -59,11 +59,7 @@ jobs:
       id: check_file
       uses: thebinaryfelix/check-file-existence-action@1.0.0
       with:
-        files: 'input/input.mv.db'
-
-    - name: Files exist
-      if: steps.check_files.outputs.exists == 'false'
-      run: exit 1
+        files: 'input/input.mv.db, input/EUROMODpolicySchedule.xlsx, input/DatabaseCountryYear.xlsx'
 
     - name: Do one run
       run: java -jar multirun.jar -p 50000 -s 2017 -e 2020 -r 100 -n 2 -g false

--- a/.github/workflows/SimPathsBuild.yml
+++ b/.github/workflows/SimPathsBuild.yml
@@ -57,7 +57,7 @@ jobs:
 
     - name: Check input db exists
       id: check_file
-      uses: thebinaryfelix/check-file-existence-action@v1
+      uses: thebinaryfelix/check-file-existence-action@1.0.0
       with:
         files: 'input/impoot.mv.db'
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ To run the SimPathsStart setup phases and set up a population for subsequent mul
 - `-c` Country ['UK' or 'IT']
 - `-s` Start year
 - `-g` [true/false] show/hide gui
+- `-r` Re-write policy schedule from detected policy files
 - `-Setup` do setup phases (creating input populations database) only
 
 e.g.
@@ -70,12 +71,14 @@ For multiple runs, `multirun.jar` takes the following options:
 - `-s` start year of runs
 - `-e` end year of runs
 - `-g` [true/false] show/hide gui
-- `-f` write console output to file (in 'output/logs/run_[seed].txt')
+- `-f` write console output and logs to file (in 'output/logs/run_[seed].txt')
 
 e.g.
 ```
 $ java -jar multirun.jar -r 100 -p 50000 -n 20 -s 2017 -e 2020 -g false -f
 ```
+
+Run `java -jar singlerun.jar -h` or `java -jar multirun.jar -h` to show these help messages.
 
 ### Contributing
 

--- a/src/main/java/simpaths/data/Parameters.java
+++ b/src/main/java/simpaths/data/Parameters.java
@@ -1795,7 +1795,9 @@ public class Parameters {
             MultiKey k = (MultiKey)o;
             if(k.getKey(0) != null) {
                 String name = k.getKey(0).toString();
-                if(name != null) {
+                if(name != null &&
+                        currentEUROMODpolicySchedule.getValue(name, EUROMODpolicyScheduleHeadingScenarioYearBegins) != null &&
+                        currentEUROMODpolicySchedule.getValue(name, EUROMODpolicyScheduleHeadingScenarioSystemYear) != null) {
                     String policyStartYearString = currentEUROMODpolicySchedule.getValue(name, EUROMODpolicyScheduleHeadingScenarioYearBegins).toString();
                     String policySystemYearString = currentEUROMODpolicySchedule.getValue(name, EUROMODpolicyScheduleHeadingScenarioSystemYear).toString();
                     if(policyStartYearString != null && !policyStartYearString.isEmpty()) {

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -167,7 +167,7 @@ public class SimPathsMultiRun extends MultiRun {
 		} catch (ParseException e) {
 			System.err.println("Error parsing command line arguments: " + e.getMessage());
 			formatter.printHelp("SimPathsMultiRun", options);
-			System.exit(1);
+			return false;
 		}
 
 		return true;

--- a/src/main/java/simpaths/experiment/SimPathsStart.java
+++ b/src/main/java/simpaths/experiment/SimPathsStart.java
@@ -88,7 +88,7 @@ public class SimPathsStart implements ExperimentBuilder {
 				runGUIlessSetup(4);
 			} catch (FileNotFoundException f) {
 				System.err.println(f.getMessage());
-				return;
+				System.exit(1);
 			};
 		}
 
@@ -229,9 +229,9 @@ public class SimPathsStart implements ExperimentBuilder {
 
 		// Create EUROMODPolicySchedule input from files
 		if (!rewritePolicySchedule &&
-				!new File("input" + File.separator + Parameters.EUROMODpolicyScheduleFilename + ".xlsx", country.toString()).exists()) {
+				!new File("input" + File.separator + Parameters.EUROMODpolicyScheduleFilename + ".xlsx").exists()) {
 			throw new FileNotFoundException("Policy Schedule file '"+ File.separator + "input" + File.separator +
-					Parameters.EUROMODpolicyScheduleFilename + ".xlsx` doesn't exist with worksheet '" + country.toString() + "'. " +
+					Parameters.EUROMODpolicyScheduleFilename + ".xlsx` doesn't exist. " +
 					"Provide excel file or use `--rewrite-policy-schedule` to re-construct from available policy files.");
 		};
 		if (rewritePolicySchedule) writePolicyScheduleExcelFile();

--- a/src/main/java/simpaths/experiment/SimPathsStart.java
+++ b/src/main/java/simpaths/experiment/SimPathsStart.java
@@ -161,7 +161,11 @@ public class SimPathsStart implements ExperimentBuilder {
 			}
 
 			if (cmd.hasOption("c")) {
-				country = Country.valueOf(cmd.getOptionValue("c"));
+				try {
+					country = Country.valueOf(cmd.getOptionValue("c"));
+				} catch (Exception e) {
+					throw new IllegalArgumentException("Code '" + cmd.getOptionValue("c") + "' not a valid country.");
+				}
 			}
 
 			if (cmd.hasOption("s")) {
@@ -178,7 +182,7 @@ public class SimPathsStart implements ExperimentBuilder {
 		} catch (ParseException | IllegalArgumentException e) {
 			System.err.println("Error parsing command line arguments: " + e.getMessage());
 			formatter.printHelp("SimPathsStart", options);
-			System.exit(1);
+			return false;
 		}
 
 		return true;

--- a/src/main/java/simpaths/experiment/SimPathsStart.java
+++ b/src/main/java/simpaths/experiment/SimPathsStart.java
@@ -5,10 +5,7 @@ package simpaths.experiment;
 import java.awt.Dimension;
 import org.apache.commons.cli.*;
 import java.awt.Toolkit;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
+import java.io.*;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -87,7 +84,12 @@ public class SimPathsStart implements ExperimentBuilder {
 			// display dialog box to allow users to define desired simulation
 			runGUIdialog();
 		} else {
-			runGUIlessSetup(4);
+			try {
+				runGUIlessSetup(4);
+			} catch (FileNotFoundException f) {
+				System.err.println(f.getMessage());
+				return;
+			};
 		}
 
 		if (setupOnly) {
@@ -214,7 +216,7 @@ public class SimPathsStart implements ExperimentBuilder {
 		model.setCollector(collector);
 	}
 
-	private static void runGUIlessSetup(int option) {
+	private static void runGUIlessSetup(int option) throws FileNotFoundException {
 
 		// Detect if data available; set to testing data if not
 		Collection<File> testList = FileUtils.listFiles(new File(Parameters.getInputDirectoryInitialPopulations()), new String[]{"csv"}, false);
@@ -226,6 +228,12 @@ public class SimPathsStart implements ExperimentBuilder {
 		Parameters.setTaxDonorInputFileName(taxDonorInputFilename);
 
 		// Create EUROMODPolicySchedule input from files
+		if (!rewritePolicySchedule &&
+				!new File("input" + File.separator + Parameters.EUROMODpolicyScheduleFilename + ".xlsx", country.toString()).exists()) {
+			throw new FileNotFoundException("Policy Schedule file '"+ File.separator + "input" + File.separator +
+					Parameters.EUROMODpolicyScheduleFilename + ".xlsx` doesn't exist with worksheet '" + country.toString() + "'. " +
+					"Provide excel file or use `--rewrite-policy-schedule` to re-construct from available policy files.");
+		};
 		if (rewritePolicySchedule) writePolicyScheduleExcelFile();
 		//Save the last selected country and year to Excel to use in the model if GUI launched straight away
 		String[] columnNames = {"Country", "Year"};

--- a/src/main/java/simpaths/experiment/SimPathsStart.java
+++ b/src/main/java/simpaths/experiment/SimPathsStart.java
@@ -67,6 +67,8 @@ public class SimPathsStart implements ExperimentBuilder {
 
 	private static boolean setupOnly = false;
 
+	private static boolean rewritePolicySchedule = false;
+
 
 	/**
 	 *
@@ -130,6 +132,9 @@ public class SimPathsStart implements ExperimentBuilder {
 		Option setupOption = new Option("Setup", "Setup only");
 		options.addOption(setupOption);
 
+		Option rewritePolicyScheduleOption = new Option("r", "rewrite-policy-schedule",false, "Re-write policy schedule from detected policy files");
+		options.addOption(rewritePolicyScheduleOption);
+
 		Option guiOption = new Option("g", "showGui", true, "Show GUI");
 		guiOption.setArgName("true/false");
 		options.addOption(guiOption);
@@ -163,6 +168,10 @@ public class SimPathsStart implements ExperimentBuilder {
 
 			if (cmd.hasOption("Setup")) {
 				setupOnly = true;
+			}
+
+			if (cmd.hasOption("r")) {
+				rewritePolicySchedule = true;
 			}
 		} catch (ParseException | IllegalArgumentException e) {
 			System.err.println("Error parsing command line arguments: " + e.getMessage());
@@ -217,7 +226,7 @@ public class SimPathsStart implements ExperimentBuilder {
 		Parameters.setTaxDonorInputFileName(taxDonorInputFilename);
 
 		// Create EUROMODPolicySchedule input from files
-		writePolicyScheduleExcelFile();
+		if (rewritePolicySchedule) writePolicyScheduleExcelFile();
 		//Save the last selected country and year to Excel to use in the model if GUI launched straight away
 		String[] columnNames = {"Country", "Year"};
 		Object[][] data = new Object[1][columnNames.length];

--- a/src/test/java/simpaths/experiment/SimPathsStartTest.java
+++ b/src/test/java/simpaths/experiment/SimPathsStartTest.java
@@ -22,7 +22,7 @@ public class SimPathsStartTest {
     @BeforeEach
     public void resetStreams() {
         outContent.reset();
-//        errContent.reset();
+        errContent.reset();
     }
 
     @Test
@@ -47,5 +47,13 @@ public class SimPathsStartTest {
         assertEquals("", errContent.toString().trim());
     }
 
-    // Add more test methods for other scenarios as needed
+    @Test
+    public void testBadCountryName() {
+        String[] args = {"-g", "false", "-s", "2017", "-c", "XX"};
+
+        String expectedError = "Code 'XX' not a valid country.";
+
+        SimPathsStart.main(args);
+        assertTrue(errContent.toString().contains(expectedError));
+    }
 }


### PR DESCRIPTION
Closes #44 by adding an option to not rebuild Excel file and exit with error if no file found.