### PR TITLE
Updated JAS-mine version and fixed missing columns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
 		<dependency>
 			<groupId>com.github.jasmineRepo</groupId>
 			<artifactId>JAS-mine-core</artifactId>
-			<version>4.3.6</version>
+			<version>4.3.7</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
 		<dependency>
 			<groupId>com.github.jasmineRepo</groupId>
 			<artifactId>JAS-mine-core</artifactId>
-			<version>4.3.7</version>
+			<version>4.3.9</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/simpaths/data/SQLdataParser.java
+++ b/src/main/java/simpaths/data/SQLdataParser.java
@@ -49,6 +49,8 @@ public class SQLdataParser {
 				+ "CREATE TABLE " + personTable + " AS (SELECT " + stringAppender(inputPersonColumnNamesSet) + " FROM " + inputFileName + ");"
 				//Add id column
 				+ "ALTER TABLE " + personTable + " ALTER COLUMN idperson RENAME TO id;"
+				//Add working_id column
+				+ "ALTER TABLE " + personTable + " ADD COLUMN working_id INT DEFAULT 0;"
 				//Add rest of PanelEntityKey
 				+ "ALTER TABLE " + personTable + " ADD COLUMN simulation_time INT DEFAULT " + startyear + ";"
 				+ "ALTER TABLE " + personTable + " ADD COLUMN simulation_run INT DEFAULT 0;"
@@ -289,6 +291,9 @@ public class SQLdataParser {
 				+ "ALTER TABLE " + benefitUnitTable + " ADD COLUMN simulation_time INT DEFAULT " + startyear + ";"
 				+ "ALTER TABLE " + benefitUnitTable + " ADD COLUMN simulation_run INT DEFAULT 0;"
 
+				//Add working_id column
+				+ "ALTER TABLE " + benefitUnitTable + " ADD COLUMN working_id INT DEFAULT 0;"
+
 				+ "ALTER TABLE " + benefitUnitTable + " ADD region VARCHAR_IGNORECASE;"
 			);
 
@@ -354,6 +359,8 @@ public class SQLdataParser {
 							+ "CREATE TABLE " + householdTable + " AS (SELECT " + stringAppender(inputHouseholdColumnNameSet) + " FROM " + inputFileName + ");"
 							+ "ALTER TABLE " + householdTable + " ADD COLUMN simulation_time INT DEFAULT " + startyear + ";"
 							+ "ALTER TABLE " + householdTable + " ADD COLUMN simulation_run INT DEFAULT 0;"
+							//Add working_id column
+							+ "ALTER TABLE " + householdTable + " ADD COLUMN working_id INT DEFAULT 0;"
 							+ "ALTER TABLE " + householdTable + " ALTER COLUMN idhh RENAME TO id;"
 							+ "SELECT * FROM " + householdTable + " ORDER BY id;"
 			);


### PR DESCRIPTION
I had updated to latest JAS-mine release and as I'd noted in email it was failing to find the column `working_id` in SQL queries. This didn't seem to be added in the same way as the other run-related columns (`simulation_run` etc.) - have added placeholder lines unless this column is meant to take on a particular value?