### PR TITLE
Changed first run database reading back to root database

### DIFF
--- a/src/main/java/simpaths/model/SimPathsModel.java
+++ b/src/main/java/simpaths/model/SimPathsModel.java
@@ -2275,7 +2275,7 @@ public class SimPathsModel extends AbstractSimulationManager implements EventLis
             if (isFirstRun) {
 
                 Class.forName("org.h2.Driver");
-                conn = DriverManager.getConnection("jdbc:h2:file:" + DatabaseUtils.databaseInputUrl + ";TRACE_LEVEL_FILE=0;TRACE_LEVEL_SYSTEM_OUT=0;AUTO_SERVER=TRUE", "sa", "");
+                conn = DriverManager.getConnection("jdbc:h2:file:./input" + File.separator + "input;TRACE_LEVEL_FILE=0;TRACE_LEVEL_SYSTEM_OUT=0;AUTO_SERVER=TRUE", "sa", "");
                 TaxDonorDataParser.updateDefaultDonorTables(conn, country);
             }
         }


### PR DESCRIPTION
# What
- Undoes the changes in #82 for at least one case - accessing the root database on first run

# Why
- This seems to a) speed it up and b) not crash it on run 2!
- Not sure why this happens overall.