### PR TITLE
Update dhe name in 02_create_UKHLS_variables.do

### DIFF
--- a/input/InitialPopulations/compile/02_create_UKHLS_variables.do
+++ b/input/InitialPopulations/compile/02_create_UKHLS_variables.do
@@ -441,7 +441,7 @@ lab var dls "DEMOGRAPHIC: Life Satisfaction"
 
 preserve
 drop if dgn < 0 | dag<0 | dhe<0
-eststo predict_dls: reg dls c.dag i.dgn i.swv i.dhe c.dhm c.dwb_mcs, vce(robust) // Physical health has a big impact, so included as covariate.  
+eststo predict_dls: reg dls c.dag i.dgn i.swv i.dhe c.dhm c.dhe_mcs, vce(robust) // Physical and mental health have a big impact, so included as covariate.  
 restore
 estimates restore predict_dls
 predict dls_prediction


### PR DESCRIPTION
# What

- corrects `dwb_mcs` to `dhe_mcs` in L444 when using as a covariate for dls `prediction`
- Closes #115 

# Why

- the old name `dwb` no longer exists!