### PR TITLE
Update training data for newly added variables: mcs pcs and life satisfaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To run the SimPathsStart setup phases and set up a population for subsequent mul
 - `-c` Country ['UK' or 'IT']
 - `-s` Start year
 - `-g` [true/false] show/hide gui
-- `-r` Re-write policy schedule from detected policy files
+- `--rewrite-policy-schedule` Re-write policy schedule from detected policy files
 - `-Setup` do setup phases (creating input populations database) only
 
 e.g.


### PR DESCRIPTION
# What
- Adds new training data with three further variables: `dhe_mcs` `dhe_pcs` and `dls`
- Minor change in readme file for clarity on single run options

# Why
- This closes #114
- Setting up for further development using these variables
- GitHub actions now has access to these for test runs.