### PR TITLE
Experimental/efficient parallel

### DIFF
--- a/.github/workflows/SimPathsBuild.yml
+++ b/.github/workflows/SimPathsBuild.yml
@@ -63,3 +63,65 @@ jobs:
 
     - name: Do one run
       run: java -jar multirun.jar -p 20000 -s 2019 -e 2022 -r 100 -n 2 -g false
+
+  run-simpaths-no-persist:
+    needs: build
+
+    runs-on: [ ubuntu-latest ]
+
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 19
+      uses: actions/setup-java@v4
+      with:
+        java-version: '19'
+        distribution: 'temurin'
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: simpaths_jars
+        path: .
+
+    - name: Setup run
+      run: java -jar singlerun.jar -c UK -s 2017 -Setup -g false --rewrite-policy-schedule
+
+    - name: Check input db exists
+      id: check_file
+      uses: thebinaryfelix/check-file-existence-action@1.0.0
+      with:
+        files: 'input/input.mv.db, input/EUROMODpolicySchedule.xlsx, input/DatabaseCountryYear.xlsx'
+
+    - name: Do two runs with no persistence
+      run: java -jar multirun.jar -p 20000 -s 2019 -e 2022 -r 100 -n 2 -g false --persist=none
+
+  run-simpaths-run-persist:
+    needs: build
+
+    runs-on: [ ubuntu-latest ]
+
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 19
+      uses: actions/setup-java@v4
+      with:
+        java-version: '19'
+        distribution: 'temurin'
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: simpaths_jars
+        path: .
+
+    - name: Setup run
+      run: java -jar singlerun.jar -c UK -s 2017 -Setup -g false --rewrite-policy-schedule
+
+    - name: Check input db exists
+      id: check_file
+      uses: thebinaryfelix/check-file-existence-action@1.0.0
+      with:
+        files: 'input/input.mv.db, input/EUROMODpolicySchedule.xlsx, input/DatabaseCountryYear.xlsx'
+
+    - name: Do two runs with no persistence
+      run: java -jar multirun.jar -p 20000 -s 2019 -e 2022 -r 100 -n 2 -g false --persist=run

--- a/.github/workflows/SimPathsBuild.yml
+++ b/.github/workflows/SimPathsBuild.yml
@@ -61,8 +61,8 @@ jobs:
       with:
         files: 'input/input.mv.db, input/EUROMODpolicySchedule.xlsx, input/DatabaseCountryYear.xlsx'
 
-    - name: Do one run
-      run: java -jar multirun.jar -p 20000 -s 2019 -e 2022 -r 100 -n 2 -g false
+    - name: Do two runs with persistence to root database
+      run: java -jar multirun.jar -p 20000 -s 2019 -e 2022 -r 100 -n 2 -g false --persist=root
 
   run-simpaths-no-persist:
     needs: build
@@ -123,5 +123,5 @@ jobs:
       with:
         files: 'input/input.mv.db, input/EUROMODpolicySchedule.xlsx, input/DatabaseCountryYear.xlsx'
 
-    - name: Do two runs with no persistence
+    - name: Do two runs with persistence to run-specific database
       run: java -jar multirun.jar -p 20000 -s 2019 -e 2022 -r 100 -n 2 -g false --persist=run

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -56,6 +56,8 @@ public class SimPathsMultiRun extends MultiRun {
 	private Long counter = 0L;
 	public static Logger log = Logger.getLogger(SimPathsMultiRun.class);
 
+	private static boolean persist_root;
+
 	/**
 	 *
 	 * 	MAIN PROGRAM ENTRY FOR MULTI-SIMULATION
@@ -148,6 +150,11 @@ public class SimPathsMultiRun extends MultiRun {
 		Option fileOption = new Option("f", "Output to file");
 		options.addOption(fileOption);
 
+		Option persistRoot = new Option("persistRootDatabase",
+				"Write and read processed database to root database" +
+				"(default: multirun copy in output folder)");
+		options.addOption(persistRoot);
+
 		Option helpOption = new Option("h", "help", false, "Print this help message");
 		options.addOption(helpOption);
 
@@ -189,6 +196,13 @@ public class SimPathsMultiRun extends MultiRun {
 			if (cmd.hasOption("p")) {
 				popSize = Integer.parseInt(cmd.getOptionValue("p"));
 			}
+
+			if (cmd.hasOption("persistRootDatabase")) {
+				persist_root = true;
+			} else {
+				persist_root = false;
+			}
+
 			if (cmd.hasOption("f")) {
 				try {
 					File logDir = new File("output/logs");
@@ -361,6 +375,7 @@ public class SimPathsMultiRun extends MultiRun {
 	public void buildExperiment(SimulationEngine engine) {
 
 		SimPathsModel model = new SimPathsModel(Country.getCountryFromNameString(countryString), startYear);
+		if (persist_root) model.setPersistDatabasePath("./input/input");
 		updateLocalParameters(model);
 		if (modelArgs != null)
 			updateParameters(model, modelArgs);

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -150,7 +150,7 @@ public class SimPathsMultiRun extends MultiRun {
 		Option fileOption = new Option("f", "Output to file");
 		options.addOption(fileOption);
 
-		Option persistRoot = new Option("persistRootDatabase",
+		Option persistRoot = new Option("P", "persistRootDatabase", false,
 				"Write and read processed database to root database" +
 				"(default: multirun copy in output folder)");
 		options.addOption(persistRoot);

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -202,8 +202,7 @@ public class SimPathsMultiRun extends MultiRun {
 				popSize = Integer.parseInt(cmd.getOptionValue("p"));
 			}
 
-			if (cmd.hasOption("P")) {
-				switch (cmd.getOptionValue("P")) {
+				switch (cmd.getOptionValue("P", "run")) {
 					case "root":
 						log.info("Persisting processed data to root folder");
 						persist_population = true;
@@ -218,12 +217,11 @@ public class SimPathsMultiRun extends MultiRun {
 						log.info("Not persisting processed data");
 						persist_population = false;
 						persist_root = false;
+					default:
+						System.out.println("Persist option `" + cmd.getOptionValue("P") + "` not recognised. Valid values: `none`, `root`, `run`. Persisting processed data to run folder");
+						persist_population = true;
+						persist_root = false;
 				}
-			} else {
-				log.info("Persisting processed data to run folder");
-				persist_population = true;
-				persist_root = false;
-			}
 
 			if (cmd.hasOption("f")) {
 				try {

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -217,6 +217,7 @@ public class SimPathsMultiRun extends MultiRun {
 					case "none":
 						log.info("Not persisting processed data");
 						persist_population = false;
+						persist_root = false;
 				}
 			} else {
 				log.info("Persisting processed data to run folder");

--- a/src/main/java/simpaths/model/SimPathsModel.java
+++ b/src/main/java/simpaths/model/SimPathsModel.java
@@ -2431,7 +2431,6 @@ public class SimPathsModel extends AbstractSimulationManager implements EventLis
             log.info("Found processed dataset - preparing for simulation");
             long householdIdCounter = 1L, benefitUnitIdCounter = 1L, personIdCounter = 1L;
             for ( Household originalHousehold : processed.getHouseholds()) {
-                log.info("Persistance: getting household " + householdIdCounter);
                 if (originalHousehold.getId() > householdIdCounter)
                     householdIdCounter = originalHousehold.getId();
                 for (BenefitUnit benefitUnit : originalHousehold.getBenefitUnits()) {

--- a/src/main/java/simpaths/model/SimPathsModel.java
+++ b/src/main/java/simpaths/model/SimPathsModel.java
@@ -3294,7 +3294,9 @@ public class SimPathsModel extends AbstractSimulationManager implements EventLis
         try {
 
             // query database
-            EntityManager em = Persistence.createEntityManagerFactory("starting-population").createEntityManager();
+            Map propertyMap = new HashMap();
+            propertyMap.put("hibernate.connection.url", "jdbc:h2:file:" + DatabaseUtils.databaseInputUrl + ";TRACE_LEVEL_FILE=0;TRACE_LEVEL_SYSTEM_OUT=0;AUTO_SERVER=TRUE");
+            EntityManager em = Persistence.createEntityManagerFactory("starting-population", propertyMap).createEntityManager();
             txn = em.getTransaction();
             txn.begin();
             String query = "SELECT processed FROM Processed processed LEFT JOIN FETCH processed.households households LEFT JOIN FETCH households.benefitUnits benefitUnits LEFT JOIN FETCH benefitUnits.members members WHERE processed.startYear = " + startYear + " AND processed.popSize = " + popSize + " AND processed.country = " + country + " AND processed.noTargets = " + ignoreTargetsAtPopulationLoad + " ORDER BY households.key.id";
@@ -3362,7 +3364,9 @@ public class SimPathsModel extends AbstractSimulationManager implements EventLis
         EntityTransaction txn = null;
         try {
 
-            EntityManager em = Persistence.createEntityManagerFactory("starting-population").createEntityManager();
+            Map propertyMap = new HashMap();
+            propertyMap.put("hibernate.connection.url", "jdbc:h2:file:" + DatabaseUtils.databaseInputUrl + ";TRACE_LEVEL_FILE=0;TRACE_LEVEL_SYSTEM_OUT=0;AUTO_SERVER=TRUE");
+            EntityManager em = Persistence.createEntityManagerFactory("starting-population", propertyMap).createEntityManager();
             txn = em.getTransaction();
             txn.begin();
 

--- a/src/main/java/simpaths/model/SimPathsModel.java
+++ b/src/main/java/simpaths/model/SimPathsModel.java
@@ -300,6 +300,8 @@ public class SimPathsModel extends AbstractSimulationManager implements EventLis
     Random popAlignInnov;
     Random educationInnov;
 
+//    private static String RunDatabasePath = RunDatabasePath;
+    private static String RunDatabasePath;
 
     /**
      *
@@ -361,6 +363,9 @@ public class SimPathsModel extends AbstractSimulationManager implements EventLis
         }
         long elapsedTime1 = System.currentTimeMillis();
         System.out.println("Time to load parameters: " + (elapsedTime1 - elapsedTime0)/1000. + " seconds.");
+
+        RunDatabasePath = DatabaseUtils.databaseInputUrl;
+
         elapsedTime0 = elapsedTime1;
 
         // populate tax donor references
@@ -2288,7 +2293,7 @@ public class SimPathsModel extends AbstractSimulationManager implements EventLis
             if (isFirstRun) {
 
                 Class.forName("org.h2.Driver");
-                conn = DriverManager.getConnection("jdbc:h2:file:./input" + File.separator + "input;TRACE_LEVEL_FILE=0;TRACE_LEVEL_SYSTEM_OUT=0;AUTO_SERVER=TRUE", "sa", "");
+                conn = DriverManager.getConnection("jdbc:h2:file:" + RunDatabasePath + ";TRACE_LEVEL_FILE=0;TRACE_LEVEL_SYSTEM_OUT=0;AUTO_SERVER=TRUE", "sa", "");
                 TaxDonorDataParser.updateDefaultDonorTables(conn, country);
             }
         }
@@ -2310,9 +2315,9 @@ public class SimPathsModel extends AbstractSimulationManager implements EventLis
         Statement stat = null;
         try {
             Class.forName("org.h2.Driver");
-            System.out.println("Reading from database at " + DatabaseUtils.databaseInputUrl);
+            System.out.println("Reading from database at " + RunDatabasePath);
             try {
-                conn = DriverManager.getConnection("jdbc:h2:"+DatabaseUtils.databaseInputUrl + ";TRACE_LEVEL_FILE=0;TRACE_LEVEL_SYSTEM_OUT=0;AUTO_SERVER=TRUE", "sa", "");
+                conn = DriverManager.getConnection("jdbc:h2:"+ RunDatabasePath + ";TRACE_LEVEL_FILE=0;TRACE_LEVEL_SYSTEM_OUT=0;AUTO_SERVER=TRUE", "sa", "");
             }
             catch (SQLException e) {
                 log.info(e.getMessage());
@@ -3165,7 +3170,7 @@ public class SimPathsModel extends AbstractSimulationManager implements EventLis
 
                 // access database and obtain donor pool
                 Map propertyMap = new HashMap();
-                propertyMap.put("hibernate.connection.url", "jdbc:h2:file:" + DatabaseUtils.databaseInputUrl);
+                propertyMap.put("hibernate.connection.url", "jdbc:h2:file:" + RunDatabasePath + ";TRACE_LEVEL_FILE=0;TRACE_LEVEL_SYSTEM_OUT=0;AUTO_SERVER=TRUE");
                 EntityManager em = Persistence.createEntityManagerFactory("tax-database", propertyMap).createEntityManager();
                 txn = em.getTransaction();
                 txn.begin();
@@ -3295,7 +3300,7 @@ public class SimPathsModel extends AbstractSimulationManager implements EventLis
 
             // query database
             Map propertyMap = new HashMap();
-            propertyMap.put("hibernate.connection.url", "jdbc:h2:file:" + DatabaseUtils.databaseInputUrl + ";TRACE_LEVEL_FILE=0;TRACE_LEVEL_SYSTEM_OUT=0;AUTO_SERVER=TRUE");
+            propertyMap.put("hibernate.connection.url", "jdbc:h2:file:" + RunDatabasePath + ";TRACE_LEVEL_FILE=0;TRACE_LEVEL_SYSTEM_OUT=0;AUTO_SERVER=TRUE");
             EntityManager em = Persistence.createEntityManagerFactory("starting-population", propertyMap).createEntityManager();
             txn = em.getTransaction();
             txn.begin();
@@ -3333,7 +3338,7 @@ public class SimPathsModel extends AbstractSimulationManager implements EventLis
         try {
 
             Map propertyMap = new HashMap();
-            propertyMap.put("hibernate.connection.url", "jdbc:h2:file:" + DatabaseUtils.databaseInputUrl);
+            propertyMap.put("hibernate.connection.url", "jdbc:h2:file:" + RunDatabasePath + ";TRACE_LEVEL_FILE=0;TRACE_LEVEL_SYSTEM_OUT=0;AUTO_SERVER=TRUE");
             EntityManager em = Persistence.createEntityManagerFactory("starting-population", propertyMap).createEntityManager();
             txn = em.getTransaction();
             txn.begin();
@@ -3365,7 +3370,7 @@ public class SimPathsModel extends AbstractSimulationManager implements EventLis
         try {
 
             Map propertyMap = new HashMap();
-            propertyMap.put("hibernate.connection.url", "jdbc:h2:file:" + DatabaseUtils.databaseInputUrl + ";TRACE_LEVEL_FILE=0;TRACE_LEVEL_SYSTEM_OUT=0;AUTO_SERVER=TRUE");
+            propertyMap.put("hibernate.connection.url", "jdbc:h2:file:" + RunDatabasePath + ";TRACE_LEVEL_FILE=0;TRACE_LEVEL_SYSTEM_OUT=0;AUTO_SERVER=TRUE");
             EntityManager em = Persistence.createEntityManagerFactory("starting-population", propertyMap).createEntityManager();
             txn = em.getTransaction();
             txn.begin();

--- a/src/main/java/simpaths/model/SimPathsModel.java
+++ b/src/main/java/simpaths/model/SimPathsModel.java
@@ -2423,8 +2423,10 @@ public class SimPathsModel extends AbstractSimulationManager implements EventLis
             if (households.isEmpty())
                 throw new RuntimeException("No households in processed set");
             System.out.println("Found processed dataset - preparing for simulation");
+            log.info("Found processed dataset - preparing for simulation");
             long householdIdCounter = 1L, benefitUnitIdCounter = 1L, personIdCounter = 1L;
             for ( Household originalHousehold : processed.getHouseholds()) {
+                log.info("Persistance: getting household " + householdIdCounter);
                 if (originalHousehold.getId() > householdIdCounter)
                     householdIdCounter = originalHousehold.getId();
                 for (BenefitUnit benefitUnit : originalHousehold.getBenefitUnits()) {
@@ -2451,8 +2453,10 @@ public class SimPathsModel extends AbstractSimulationManager implements EventLis
             inputDatabaseInteraction();
             System.out.println("Completed initialising input dataset");
             System.out.println("Loading survey data for starting population");
+            log.info("Loading survey data for starting population");
             List<Household> inputHouseholdList = loadStaringPopulation();
             System.out.println("completed loading survey data for starting population");
+            log.info("completed loading survey data for starting population");
             if (!useWeights) {
                 // Expand population, sample, and remove weights
 
@@ -3294,8 +3298,10 @@ public class SimPathsModel extends AbstractSimulationManager implements EventLis
             txn = em.getTransaction();
             txn.begin();
             String query = "SELECT processed FROM Processed processed LEFT JOIN FETCH processed.households households LEFT JOIN FETCH households.benefitUnits benefitUnits LEFT JOIN FETCH benefitUnits.members members WHERE processed.startYear = " + startYear + " AND processed.popSize = " + popSize + " AND processed.country = " + country + " AND processed.noTargets = " + ignoreTargetsAtPopulationLoad + " ORDER BY households.key.id";
+            log.info("Submitting SQL query: " + query);
 
             List<Processed> processedList = em.createQuery(query).getResultList();
+            log.info("Query complete");
             if (!processedList.isEmpty()) {
 
                 if (processedList.size()>1)
@@ -3330,7 +3336,9 @@ public class SimPathsModel extends AbstractSimulationManager implements EventLis
             txn = em.getTransaction();
             txn.begin();
             String query = "SELECT households FROM Household households LEFT JOIN FETCH households.benefitUnits benefitUnits LEFT JOIN FETCH benefitUnits.members members";
+            log.info("Submitting SQL query: " + query);
             households = em.createQuery(query).getResultList();
+            log.info("Query complete");
 
             // close database connection
             em.close();

--- a/src/main/java/simpaths/model/SimPathsModel.java
+++ b/src/main/java/simpaths/model/SimPathsModel.java
@@ -71,6 +71,11 @@ public class SimPathsModel extends AbstractSimulationManager implements EventLis
         PersistDatabasePath = persistDatabasePath;
     }
 
+    public static void setPersistPopulation(boolean persistPopulation) {
+        PersistPopulation = persistPopulation;
+    }
+
+
     public boolean isFirstRun() {
         return isFirstRun;
     }
@@ -311,6 +316,9 @@ public class SimPathsModel extends AbstractSimulationManager implements EventLis
 //    private static String RunDatabasePath = RunDatabasePath;
     private static String RunDatabasePath;
     private static String PersistDatabasePath;
+    private static boolean PersistPopulation = false;
+
+
 
     /**
      *
@@ -2433,7 +2441,7 @@ public class SimPathsModel extends AbstractSimulationManager implements EventLis
         double aggregateHouseholdsWeight = 0.;        //Aggregate Weight of simulated benefitUnits (a weighted sum of the simulated households)
 
         //TODO: Slight differences between otherwise identical simulations arise when loading "processed" vs "unprocessed" data (distinguished by the if statement below)
-        Processed processed = getProcessed();
+        Processed processed = PersistPopulation ? getProcessed() : null;
         if (processed!=null) {
             Set<Household> households = processed.getHouseholds();
             if (households.isEmpty())
@@ -2580,8 +2588,11 @@ public class SimPathsModel extends AbstractSimulationManager implements EventLis
             }
 
             // save to processed repository
-            System.out.println("Saving compiled input data for future reference");
-            persistProcessed();
+
+            if (PersistPopulation) {
+                System.out.println("Saving compiled input data for future reference");
+                persistProcessed();
+            }
 
             stopwatch.stop();
             System.out.println("Time elapsed " + stopwatch.getTime()/1000 + " seconds");


### PR DESCRIPTION
# Changing how populations are persisted

Partial solution to #128 

# Experiment - writing both ways

As an attempt at a solution, I have created a branch at https://github.com/centreformicrosimulation/SimPaths/tree/experimental/efficient_parallel which adds a new option to `SimPathsMultiRun` to read/write persistence *either* to the root database or the run database.

# Problem

Reminder of the problem. When running multiple runs in parallel:
- If it reads/writes to root database, blocks parallel runs
- If it reads/writes to run database, runs vvvv slowly (about 4 hours to `getProcessed`)

# Solution

This branch will read/write persistence *either* to the root database or the run database. This allows an initial nothing-run to establish a starting population and write successfully to the root database. Subsequent runs then copy this, skip the slow code of population initialisation, then successfully load a persisted population to start a run very quickly!

# Test to run

Compile jar files (in project folder:

```
mvn clean package
```

As a setup in the run, if you run first a read/write to root database:

```sh
java -jar singlerun.jar -c UK -s 2011 -Setup -g false
java -jar multirun.jar -s 2011 -e 2011 -p 200000 -n 1 -r 999 -g false -persistRootDatabase
```

Followed by a multirun reading/writing to run database:

```sh
java -jar multirun.jar -s 2011 -e 2020 -p 200000 -n 100 -r 100 -g false -f
```

As long as start year and pop size remain constant, the per-run setup for a larg-ish pop (200,000) drops from four hours ***to thirteen seconds***