### PR TITLE
Adding benefits receipt and UC/NonUC markers to initial populations

### DIFF
--- a/input/InitialPopulations/compile/01_prepare_UKHLS_pooled_data.do
+++ b/input/InitialPopulations/compile/01_prepare_UKHLS_pooled_data.do
@@ -173,6 +173,23 @@ collapse (sum) inc_pp inc_tu inc_ma inc_fm inc_oth, by(swv pidp hidp)
 save "$dir_data\tmp_income", replace
 restore
 
+/******************************Benefits receipt *****************************/
+
+preserve
+* Generate UC benefit marker
+gen benefits_uc=(ficode==40)
+label var benefits_uc "Universal Credit indicator"
+
+
+keep hidp pidp swv benefits_uc
+collapse (max) benefits_uc, by(hidp swv)
+compress
+
+save "$dir_data/tmp_ucrcpt", replace
+restore
+
+
+
 //merge variables from the youth dataset 9-18 years old * 
 foreach w of global UKHLSwaves {
 
@@ -190,22 +207,6 @@ foreach w of global UKHLSwaves {
 		save "$dir_data\add_vars_ukhls_youth.dta", replace
 	}
 }
-
-/******************************Benefits receipt *****************************/
-
-preserve
-* Generate UC benefit marker
-gen benefits_uc=(ficode==40)
-label var benefits_uc "Universal Credit indicator"
-
-
-keep hidp pidp swv benefits_uc
-collapse (max) benefits_uc, by(hidp swv)
-compress
-
-save "$dir_data/tmp_ucrcpt", replace
-restore
-
 
 //merge variables from the youth dataset 9-18 years old * 
 

--- a/input/InitialPopulations/compile/01_prepare_UKHLS_pooled_data.do
+++ b/input/InitialPopulations/compile/01_prepare_UKHLS_pooled_data.do
@@ -117,16 +117,16 @@ foreach w of global UKHLSwaves {
 	local waveno=strpos("abcdefghijklmnopqrstuvwxyz","`w'")
 
 	if (`waveno'==1) {
-		use `w'_hidp `w'_fihhmnnet1_dv `w'_fihhmngrs1_dv  `w'_nch02_dv /*`w'_hhdenub_xw `w'_hhdenui_xw*/ `w'_hsownd using `w'_hhresp.dta, clear
+		use `w'_hidp `w'_fihhmnnet1_dv `w'_fihhmngrs1_dv `w'_fihhmnsben_dv `w'_nch02_dv /*`w'_hhdenub_xw `w'_hhdenui_xw*/ `w'_hsownd using `w'_hhresp.dta, clear
 	}
 	else if (`waveno'<6) {
-		use `w'_hidp `w'_fihhmnnet1_dv `w'_fihhmngrs1_dv `w'_nch02_dv `w'_hhdenub_xw /*`w'_hhdenui_xw*/ `w'_hsownd using `w'_hhresp.dta, clear
+		use `w'_hidp `w'_fihhmnnet1_dv `w'_fihhmngrs1_dv `w'_fihhmnsben_dv `w'_nch02_dv `w'_hhdenub_xw /*`w'_hhdenui_xw*/ `w'_hsownd using `w'_hhresp.dta, clear
 	}
 	else if (`waveno'<14) {
-		use `w'_hidp `w'_fihhmnnet1_dv `w'_fihhmngrs1_dv `w'_nch02_dv /*`w'_hhdenub_xw*/ `w'_hhdenui_xw `w'_hsownd using `w'_hhresp.dta, clear
+		use `w'_hidp `w'_fihhmnnet1_dv `w'_fihhmngrs1_dv `w'_fihhmnsben_dv `w'_nch02_dv /*`w'_hhdenub_xw*/ `w'_hhdenui_xw `w'_hsownd using `w'_hhresp.dta, clear
 	} 
 	else if (`waveno'==14) {
-		use `w'_hidp `w'_fihhmnnet1_dv `w'_fihhmngrs1_dv `w'_nch02_dv /*`w'_hhdenub_xw `w'_hhdenui_xw*/ `w'_hhdeng2_xw `w'_hsownd using `w'_hhresp.dta, clear
+		use `w'_hidp `w'_fihhmnnet1_dv `w'_fihhmngrs1_dv `w'_fihhmnsben_dv `w'_nch02_dv /*`w'_hhdenub_xw `w'_hhdenui_xw*/ `w'_hhdeng2_xw `w'_hsownd using `w'_hhresp.dta, clear
 	}
 	
 	gen swv = `waveno'

--- a/input/InitialPopulations/compile/02_create_UKHLS_variables.do
+++ b/input/InitialPopulations/compile/02_create_UKHLS_variables.do
@@ -1377,6 +1377,26 @@ la var bdi "Disability benefits"
 gen unemp = (jbstat==3)
 label variable unemp "Labour status: unemployed"
 
+/***************************** UC and Non-UC receipt ************************/
+
+gen econ_benefits = .
+replace econ_benefits = 1 if fihhmnsben_dv > 0 & fihhmnsben_dv!=.
+replace econ_benefits = 0 if fihhmnsben_dv==0
+label var econ_benefits "Household income includes any benefits"
+
+replace benefits_uc=0 if benefits_uc==.
+* Ensure all with known UC receipt also are benefit recipients
+replace econ_benefits=1 if benefits_uc==1
+
+* Generate benefits marker without UC
+gen econ_benefits_nonuc=econ_benefits
+replace econ_benefits_nonuc=0 if benefits_uc==1
+label var econ_benefits_nonuc "Household income includes non-UC benefits"
+
+* Generate benefits marker with UC
+gen econ_benefits_uc=econ_benefits
+replace econ_benefits_uc=0 if benefits_uc==0
+label var econ_benefits_uc "Household income includes UC benefits"
 
 /*****************Was in continuous education sample***************************/
 //Generated from age_dv and ded variables. 1 includes first instance of not being in education.
@@ -1453,6 +1473,7 @@ keep ivfio idhh idperson idpartner idfather idmother dct drgn1 dwt dnc02 dnc dgn
 	ded deh_c3 der dehsp_c3 dehm_c3 dehf_c3 dehmf_c3 dcpen dcpyy dcpex dcpagdf dlltsd dlrtrd drtren dlftphm dhhtp_c4 dhm dhm_ghq dimlwt disclwt ///
 	dimxwt dhhwt jbhrs jshrs j2hrs jbstat les_c3 les_c4 lessp_c3 lessp_c4 lesdf_c4 ydses_c5 month scghq2_dv ///
 	ypnbihs_dv yptciihs_dv yplgrs_dv ynbcpdf_dv ypncp ypnoab swv sedex ssscp sprfm sedag stm dagsp lhw pno ppno hgbioad1 hgbioad2 der adultchildflag ///
+        econ_benefits econ_benefits_nonuc econ_benefits_uc ///
 	sedcsmpl sedrsmpl scedsmpl dhh_owned dukfr dchpd dagpns dagpns_sp CPI lesnr_c2 dlltsd_sp ypnoab_lvl *_flag  Int_Date dhe_mcs dhe_pcs dls dot unemp 
 
 sort swv idhh idperson 
@@ -1463,6 +1484,7 @@ foreach var in idhh idperson idpartner idfather idmother dct drgn1 dwt dnc02 dnc
 	ded deh_c3 der dehsp_c3 dehm_c3 dehf_c3 dehmf_c3 dcpen dcpyy dcpex dlltsd dlrtrd drtren dlftphm dhhtp_c4 dhm dhm_ghq ///
 	jbhrs jshrs j2hrs jbstat les_c3 les_c4 lessp_c3 lessp_c4 lesdf_c4 ydses_c5 scghq2_dv ///
 	ypnbihs_dv yptciihs_dv yplgrs_dv swv sedex ssscp sprfm sedag stm dagsp lhw pno ppno hgbioad1 hgbioad2 der dhh_owned ///
+        econ_benefits econ_benefits_nonuc econ_benefits_uc ///
 	scghq2_dv_miss_flag dchpd dagpns dagpns_sp CPI lesnr_c2 dlltsd_sp ypnoab_lvl *_flag dhe_mcs dhe_pcs dls dot unemp {
 		qui recode `var' (-9/-1=-9) (.=-9) 
 }

--- a/input/InitialPopulations/compile/02_create_UKHLS_variables.do
+++ b/input/InitialPopulations/compile/02_create_UKHLS_variables.do
@@ -1484,6 +1484,8 @@ replace l1_potential_earnings_hourly = 0 if missing(l1_potential_earnings_hourly
 		
 * initialise wealth to missing 
 gen liquid_wealth = -9
+gen tot_pen = -9
+gen nvmhome = -9
 gen smp = -9
 gen rnk = -9
 gen mtc = -9

--- a/input/InitialPopulations/compile/09_finalise_input_data.do
+++ b/input/InitialPopulations/compile/09_finalise_input_data.do
@@ -184,16 +184,19 @@ forvalues yy = $firstSimYear/$lastSimYear {
 	yplgrs_dv ypnbihs_dv yptciihs_dv dhhtp_c4 ssscp dcpen dcpyy dcpex dcpagdf ynbcpdf_dv der sedag sprfm dagsp dehsp_c3 dhesp lessp_c3 dehm_c3 dehf_c3 ///
 	stm lesdf_c4 ppno dhm scghq2_dv dhh_owned lhw drgn1 dct dwt_sampling les_c4 dhm_ghq lessp_c4 adultchildflag multiplier dwt ///
 	potential_earnings_hourly l1_potential_earnings_hourly liquid_wealth tot_pen nvmhome need_socare formal_socare_hrs partner_socare_hrs daughter_socare_hrs son_socare_hrs other_socare_hrs formal_socare_cost ///
+        econ_benefits econ_benefits_nonuc econ_benefits_uc ///
 	ypncp ypnoab aidhrs carewho dhe_mcs dhe_pcs dls dot unemp  
 	
 	order idhh idbenefitunit idperson idpartner idmother idfather pno swv dgn dag dcpst dnc02 dnc ded deh_c3 sedex jbstat les_c3 dlltsd dhe ydses_c5 yplgrs_dv ypnbihs_dv yptciihs_dv dhhtp_c4 ssscp dcpen ///
 	dcpyy dcpex dcpagdf ynbcpdf_dv der sedag sprfm dagsp dehsp_c3 dhesp lessp_c3 dehm_c3 dehf_c3 stm lesdf_c4 ppno dhm scghq2_dv dhh_owned lhw drgn1 dct dwt_sampling les_c4 dhm_ghq lessp_c4 adultchildflag ///
 	multiplier dwt potential_earnings_hourly l1_potential_earnings_hourly liquid_wealth tot_pen nvmhome need_socare formal_socare_hrs partner_socare_hrs daughter_socare_hrs son_socare_hrs other_socare_hrs formal_socare_cost ///
+        econ_benefits econ_benefits_nonuc econ_benefits_uc ///
 	ypncp ypnoab aidhrs carewho dhe_mcs dhe_pcs dls dot unemp 
 	
 	recode idhh idbenefitunit idperson idpartner idmother idfather pno swv dgn dag dcpst dnc02 dnc ded deh_c3 sedex jbstat les_c3 dlltsd dhe ydses_c5 yplgrs_dv ypnbihs_dv yptciihs_dv dhhtp_c4 ssscp ///
 	dcpen dcpyy dcpex dcpagdf ynbcpdf_dv der sedag sprfm dagsp dehsp_c3 dhesp lessp_c3 dehm_c3 dehf_c3 stm lesdf_c4 ppno dhm scghq2_dv dhh_owned lhw drgn1 dct dwt_sampling les_c4 dhm_ghq lessp_c4 ///
 	adultchildflag multiplier dwt potential_earnings_hourly l1_potential_earnings_hourly liquid_wealth tot_pen nvmhome need_socare formal_socare_hrs partner_socare_hrs daughter_socare_hrs son_socare_hrs other_socare_hrs ///
+        econ_benefits econ_benefits_nonuc econ_benefits_uc ///
 	formal_socare_cost ypncp ypnoab aidhrs carewho dhe_mcs dhe_pcs dls dot unemp  (missing=-9)
 	
 	gsort idhh idbenefitunit idperson

--- a/input/InitialPopulations/compile/09_finalise_input_data.do
+++ b/input/InitialPopulations/compile/09_finalise_input_data.do
@@ -183,23 +183,23 @@ forvalues yy = $firstSimYear/$lastSimYear {
 	keep idhh idbenefitunit idperson idpartner idmother idfather pno swv dgn dag dcpst dnc02 dnc ded deh_c3 sedex jbstat les_c3 dlltsd dhe ydses_c5 ///
 	yplgrs_dv ypnbihs_dv yptciihs_dv dhhtp_c4 ssscp dcpen dcpyy dcpex dcpagdf ynbcpdf_dv der sedag sprfm dagsp dehsp_c3 dhesp lessp_c3 dehm_c3 dehf_c3 ///
 	stm lesdf_c4 ppno dhm scghq2_dv dhh_owned lhw drgn1 dct dwt_sampling les_c4 dhm_ghq lessp_c4 adultchildflag multiplier dwt ///
-	potential_earnings_hourly l1_potential_earnings_hourly liquid_wealth need_socare formal_socare_hrs partner_socare_hrs daughter_socare_hrs son_socare_hrs other_socare_hrs formal_socare_cost ///
+	potential_earnings_hourly l1_potential_earnings_hourly liquid_wealth tot_pen nvmhome need_socare formal_socare_hrs partner_socare_hrs daughter_socare_hrs son_socare_hrs other_socare_hrs formal_socare_cost ///
 	ypncp ypnoab aidhrs carewho dhe_mcs dhe_pcs dls dot unemp  
 	
 	order idhh idbenefitunit idperson idpartner idmother idfather pno swv dgn dag dcpst dnc02 dnc ded deh_c3 sedex jbstat les_c3 dlltsd dhe ydses_c5 yplgrs_dv ypnbihs_dv yptciihs_dv dhhtp_c4 ssscp dcpen ///
 	dcpyy dcpex dcpagdf ynbcpdf_dv der sedag sprfm dagsp dehsp_c3 dhesp lessp_c3 dehm_c3 dehf_c3 stm lesdf_c4 ppno dhm scghq2_dv dhh_owned lhw drgn1 dct dwt_sampling les_c4 dhm_ghq lessp_c4 adultchildflag ///
-	multiplier dwt potential_earnings_hourly l1_potential_earnings_hourly liquid_wealth need_socare formal_socare_hrs partner_socare_hrs daughter_socare_hrs son_socare_hrs other_socare_hrs formal_socare_cost ///
+	multiplier dwt potential_earnings_hourly l1_potential_earnings_hourly liquid_wealth tot_pen nvmhome need_socare formal_socare_hrs partner_socare_hrs daughter_socare_hrs son_socare_hrs other_socare_hrs formal_socare_cost ///
 	ypncp ypnoab aidhrs carewho dhe_mcs dhe_pcs dls dot unemp 
 	
 	recode idhh idbenefitunit idperson idpartner idmother idfather pno swv dgn dag dcpst dnc02 dnc ded deh_c3 sedex jbstat les_c3 dlltsd dhe ydses_c5 yplgrs_dv ypnbihs_dv yptciihs_dv dhhtp_c4 ssscp ///
 	dcpen dcpyy dcpex dcpagdf ynbcpdf_dv der sedag sprfm dagsp dehsp_c3 dhesp lessp_c3 dehm_c3 dehf_c3 stm lesdf_c4 ppno dhm scghq2_dv dhh_owned lhw drgn1 dct dwt_sampling les_c4 dhm_ghq lessp_c4 ///
-	adultchildflag multiplier dwt potential_earnings_hourly l1_potential_earnings_hourly liquid_wealth need_socare formal_socare_hrs partner_socare_hrs daughter_socare_hrs son_socare_hrs other_socare_hrs ///
+	adultchildflag multiplier dwt potential_earnings_hourly l1_potential_earnings_hourly liquid_wealth tot_pen nvmhome need_socare formal_socare_hrs partner_socare_hrs daughter_socare_hrs son_socare_hrs other_socare_hrs ///
 	formal_socare_cost ypncp ypnoab aidhrs carewho dhe_mcs dhe_pcs dls dot unemp  (missing=-9)
 	
 	gsort idhh idbenefitunit idperson
 	save "$dir_data/population_initial_UK_$year.dta", replace
 	
-	recode dgn liquid_wealth need_socare formal_socare_hrs partner_socare_hrs daughter_socare_hrs son_socare_hrs other_socare_hrs formal_socare_cost aidhrs carewho (-9=0)
+	recode dgn liquid_wealth tot_pen nvmhome need_socare formal_socare_hrs partner_socare_hrs daughter_socare_hrs son_socare_hrs other_socare_hrs formal_socare_cost aidhrs carewho (-9=0)
 	export delimited using "$dir_data/population_initial_UK_$year.csv", nolabel replace
 }
 


### PR DESCRIPTION
# What

- Adds three new variables: `econ_benefits`, `econ_benefits_uc` and `econ_benefits_non_uc` to initial populations
- do files to compile changed to include these variables
- training data updated to include these variables

# Why

- Three markers which can be updated and used for modelling effects of benefit receipt