### PR TITLE
Experimental/parameter parsing

### DIFF
--- a/src/main/java/simpaths/data/Parameters.java
+++ b/src/main/java/simpaths/data/Parameters.java
@@ -263,8 +263,8 @@ public class Parameters {
 
     //public static int MAX_AGE_IN_EDUCATION;// = MAX_AGE;//30;			// Max age a person can stay in education	//Cannot set here, as MAX_AGE is not known yet.  Now set to MAX_AGE in buildObjects in Model class.
     //public static int MAX_AGE_MARRIAGE;// = MAX_AGE;//75;  			// Max age a person can marry		//Cannot set here, as MAX_AGE is not known yet.  Now set to MAX_AGE in buildObjects in Model class.
-    private static final int MIN_START_YEAR = 2011; //Minimum allowed starting point. Should correspond to the oldest initial population.
-    private static final int MAX_START_YEAR = 2021; //Maximum allowed starting point. Should correspond to the most recent initial population.
+    private static int MIN_START_YEAR = 2011; //Minimum allowed starting point. Should correspond to the oldest initial population.
+    private static int MAX_START_YEAR = 2021; //Maximum allowed starting point. Should correspond to the most recent initial population.
     public static int startYear;
     public static int endYear;
     private static final int MIN_START_YEAR_TESTING = 2019;
@@ -276,7 +276,7 @@ public class Parameters {
     public static final boolean FLAG_SINGLE_MOTHERS = true;
     public static boolean flagUnemployment = false;
 
-    public static final int BASE_PRICE_YEAR = 2015; 			// Base price year of model parameters
+    public static int BASE_PRICE_YEAR = 2015; 			// Base price year of model parameters
 
     public static double PROB_NEWBORN_IS_MALE = 0.5;            // Must be strictly greater than 0.0 and less than 1.0
 

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -401,6 +401,9 @@ public class SimPathsMultiRun extends MultiRun {
 	@Override
 	public void buildExperiment(SimulationEngine engine) {
 
+		if (parameterArgs != null)
+			updateParameters(parameterArgs);
+
 		SimPathsModel model = new SimPathsModel(Country.getCountryFromNameString(countryString), startYear);
 		if (persist_population) model.setPersistPopulation(true);
 		if (persist_root) model.setPersistDatabasePath("./input/input");

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -378,6 +378,40 @@ public class SimPathsMultiRun extends MultiRun {
 		}
 	}
 
+	// Specifically for updating parameters when no object called - i.e. Parameters.java
+	public static void updateParameters(Map<String, Object> parameter_args) {
+
+		for (Map.Entry<String, Object> entry : parameter_args.entrySet()) {
+			String key = entry.getKey();
+			Object value = entry.getValue();
+
+			switch (key) {
+				default:
+					try {
+						Field field = Parameters.class.getDeclaredField(key);
+						field.setAccessible(true);
+
+						// Determine the field type
+						Class<?> fieldType = field.getType();
+
+						// Convert the YAML value to the field type
+						Object convertedValue = convertToType(value, fieldType);
+
+						// Set the field value
+						field.set(Parameters.class, convertedValue);
+
+						field.setAccessible(false);
+					} catch (NoSuchFieldException | IllegalAccessException e) {
+						// Handle exceptions if the field is not found or inaccessible
+						e.printStackTrace();
+					}
+
+			}
+
+		}
+
+	}
+
 	private static Object convertToType(Object value, Class<?> targetType) {
 		// Convert the YAML value to the target type
 		if (int.class.equals(targetType)) {

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -47,6 +47,7 @@ public class SimPathsMultiRun extends MultiRun {
 	private static Map<String, Object> modelArgs;
 	private static Map<String, Object> innovationArgs;
 	private static Map<String, Object> collectorArgs;
+	private static Map<String, Object> parameterArgs;
 	public static String configFile = "default.yml";
 
 	// other working variables
@@ -299,6 +300,12 @@ public class SimPathsMultiRun extends MultiRun {
 
 				if ("collector_args".equals(key)) {
 					collectorArgs = (Map<String, Object>) value;
+					continue;
+				}
+
+				// Read in parameter arguments - to be handled differently as no Parameters object
+				if ("parameter_args".equals(key)) {
+					parameterArgs = (Map<String, Object>) value;
 					continue;
 				}
 


### PR DESCRIPTION
# What

- Adds a startup element to `SimPathsMultiRun` which reads parameter configs from config file
- Allows some of these to be amended

# Why

- Changing parameters between runs could be done quickly with config files, rather than rebuilding the model
- This would allow script-based runs of subsequent models with tweaked parameters