### PR TITLE
reduce default popsize parameter from 170,000 to 50,000

### DIFF
--- a/src/main/java/simpaths/model/SimPathsModel.java
+++ b/src/main/java/simpaths/model/SimPathsModel.java
@@ -95,7 +95,7 @@ public class SimPathsModel extends AbstractSimulationManager implements EventLis
     private boolean flagUpdateCountry = false;  // set to true if switch between countries
 
     @GUIparameter(description = "Simulated population size (base year)")
-    private Integer popSize = 170000;
+    private Integer popSize = 50000;
 
     @GUIparameter(description = "Simulation first year [valid range 2011-2019]")
     private Integer startYear = 2011;


### PR DESCRIPTION
Minor tweak - reduces default population size to a more manageable 50,000 in the GUI parameters. Very unlikely to change much in almost any runs but perhaps a useful tweak to avoid things hanging if a new user wants to attempt a run.