### PR TITLE
Experimental/adding singlerun headless capabilty

### DIFF
--- a/.github/workflows/SimPathsBuild.yml
+++ b/.github/workflows/SimPathsBuild.yml
@@ -43,6 +43,28 @@ jobs:
     - name: Run integration tests
       run: mvn verify
 
+  run-simpaths-start:
+    needs: build
+    runs-on: [ ubuntu-latest ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 19
+        uses: actions/setup-java@v4
+        with:
+          java-version: '19'
+          distribution: 'temurin'
+      - uses: actions/download-artifact@v4
+        with:
+          name: simpaths_jars
+          path: .
+      - name: Do one full Setup and Run with SimPathsStart (mimicking GUI run)
+        run: java -jar singlerun.jar -c UK -s 2017 -g false --rewrite-policy-schedule
+      - name: Check input db exists
+        id: check_file
+        uses: thebinaryfelix/check-file-existence-action@1.0.0
+        with:
+          files: 'input/input.mv.db, input/EUROMODpolicySchedule.xlsx, input/DatabaseCountryYear.xlsx'
+
   run-simpaths-persist-root:
     needs: build
     runs-on: [ ubuntu-latest ]

--- a/.github/workflows/SimPathsBuild.yml
+++ b/.github/workflows/SimPathsBuild.yml
@@ -58,7 +58,7 @@ jobs:
           name: simpaths_jars
           path: .
       - name: Do one full Setup and Run with SimPathsStart (mimicking GUI run)
-        run: java -jar singlerun.jar -c UK -s 2017 -g false --rewrite-policy-schedule
+        run: java -jar singlerun.jar -c UK -s 2019 -g false --rewrite-policy-schedule
       - name: Check input db exists
         id: check_file
         uses: thebinaryfelix/check-file-existence-action@1.0.0

--- a/src/main/java/simpaths/experiment/SimPathsStart.java
+++ b/src/main/java/simpaths/experiment/SimPathsStart.java
@@ -217,7 +217,7 @@ public class SimPathsStart implements ExperimentBuilder {
 
 		engine.addSimulationManager(model);
 		engine.addSimulationManager(collector);
-		engine.addSimulationManager(observer);
+		if (showGui) engine.addSimulationManager(observer);
 
 		model.setCollector(collector);
 	}

--- a/src/main/java/simpaths/experiment/SimPathsStart.java
+++ b/src/main/java/simpaths/experiment/SimPathsStart.java
@@ -94,6 +94,7 @@ public class SimPathsStart implements ExperimentBuilder {
 		startYear = Integer.parseInt(valueYear);
 
 		// start the JAS-mine simulation engine
+		System.out.println("Starting simulation...");
 		final SimulationEngine engine = SimulationEngine.getInstance();
 		MicrosimShell gui = null;
 		if (showGui) {
@@ -103,6 +104,9 @@ public class SimPathsStart implements ExperimentBuilder {
 		SimPathsStart experimentBuilder = new SimPathsStart();
 		engine.setExperimentBuilder(experimentBuilder);
 		engine.setup();
+
+		if (!showGui)
+			engine.startSimulation();
 	}
 
 	private static boolean parseCommandLineArgs(String[] args) {

--- a/src/main/java/simpaths/experiment/SimPathsStart.java
+++ b/src/main/java/simpaths/experiment/SimPathsStart.java
@@ -108,13 +108,18 @@ public class SimPathsStart implements ExperimentBuilder {
 
 		if (!showGui) {
 			engine.startSimulation();
-			while (engine.getRunningStatus()) try {
-				TimeUnit.SECONDS.sleep(10);
-			} catch (InterruptedException e) {
-				System.err.println("Interrupted while waiting for simulation to complete.");
-				return;
+			try {
+				while (engine.getRunningStatus()) {
+					try {
+						TimeUnit.SECONDS.sleep(10);
+					} catch (InterruptedException e) {
+						System.err.println("Interrupted while waiting for simulation to complete.");
+						return;
+					}
+				}
+			} finally {
+				engine.quit();
 			}
-			engine.quit();
 		}
 	}
 

--- a/src/main/java/simpaths/experiment/SimPathsStart.java
+++ b/src/main/java/simpaths/experiment/SimPathsStart.java
@@ -10,6 +10,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.JInternalFrame;
@@ -105,8 +106,16 @@ public class SimPathsStart implements ExperimentBuilder {
 		engine.setExperimentBuilder(experimentBuilder);
 		engine.setup();
 
-		if (!showGui)
+		if (!showGui) {
 			engine.startSimulation();
+			while (engine.getRunningStatus()) try {
+				TimeUnit.SECONDS.sleep(10);
+			} catch (InterruptedException e) {
+				System.err.println("Interrupted while waiting for simulation to complete.");
+				return;
+			}
+			System.out.println("Simulation complete.");
+		}
 	}
 
 	private static boolean parseCommandLineArgs(String[] args) {

--- a/src/main/java/simpaths/experiment/SimPathsStart.java
+++ b/src/main/java/simpaths/experiment/SimPathsStart.java
@@ -47,7 +47,8 @@ public class SimPathsStart implements ExperimentBuilder {
 
 	private static boolean showGui = true;  // Show GUI by default
 
-	private static boolean setupOnly = false;
+	private static boolean doSetup = true;
+	private static boolean doRun = true;
 
 	private static boolean rewritePolicySchedule = false;
 
@@ -70,13 +71,13 @@ public class SimPathsStart implements ExperimentBuilder {
 			runGUIdialog();
 		} else {
 			try {
-				runGUIlessSetup(4);
+				if (doSetup) runGUIlessSetup(4);
 			} catch (FileNotFoundException f) {
 				System.err.println(f.getMessage());
 			};
 		}
 
-		if (setupOnly) {
+		if (!doRun) {
 			System.out.println("Setup complete, exiting.");
 			return;
 		}
@@ -115,8 +116,11 @@ public class SimPathsStart implements ExperimentBuilder {
 		startYearOption.setArgName("year");
 		options.addOption(startYearOption);
 
-		Option setupOption = new Option("Setup", "Setup only");
+		Option setupOption = new Option("Setup", "Setup only (no run)");
 		options.addOption(setupOption);
+
+		Option runOption = new Option("Run", "Run only (no setup)");
+		options.addOption(runOption);
 
 		Option rewritePolicyScheduleOption = new Option("r", "rewrite-policy-schedule",false, "Re-write policy schedule from detected policy files");
 		options.addOption(rewritePolicyScheduleOption);
@@ -134,6 +138,10 @@ public class SimPathsStart implements ExperimentBuilder {
 
 		try {
 			CommandLine cmd = parser.parse(options, args);
+
+			if(cmd.hasOption("Setup") && cmd.hasOption("Run")) {
+				throw new ParseException("'Run only' and 'Setup only' options cannot be used together.");
+			}
 
 			if (cmd.hasOption("h")) {
 				printHelpMessage(formatter, options);
@@ -157,7 +165,13 @@ public class SimPathsStart implements ExperimentBuilder {
 			}
 
 			if (cmd.hasOption("Setup")) {
-				setupOnly = true;
+				doSetup = true;
+				doRun = false;
+			}
+
+			if (cmd.hasOption("Run")) {
+				doRun = true;
+				doSetup = false;
 			}
 
 			if (cmd.hasOption("r")) {

--- a/src/main/java/simpaths/experiment/SimPathsStart.java
+++ b/src/main/java/simpaths/experiment/SimPathsStart.java
@@ -114,7 +114,7 @@ public class SimPathsStart implements ExperimentBuilder {
 				System.err.println("Interrupted while waiting for simulation to complete.");
 				return;
 			}
-			System.out.println("Simulation complete.");
+			engine.quit();
 		}
 	}
 

--- a/src/main/java/simpaths/model/SimPathsModel.java
+++ b/src/main/java/simpaths/model/SimPathsModel.java
@@ -95,7 +95,7 @@ public class SimPathsModel extends AbstractSimulationManager implements EventLis
     private boolean flagUpdateCountry = false;  // set to true if switch between countries
 
     @GUIparameter(description = "Simulated population size (base year)")
-    private Integer popSize = 170000;
+    private Integer popSize = 50000;
 
     @GUIparameter(description = "Simulation first year [valid range 2011-2019]")
     private Integer startYear = 2011;


### PR DESCRIPTION
# What

- This partially addresses concerns in #177 in that it allows `singlerun.jar` to do a full run
- Adds the argument `Run` to cli to potentially allow **run only** (as opposed to **setup only** - tests for mutually exclusive argument conflicts)

# Why

- Not a fully necessary step for users if #177 refactoring is useful: if we wanted to do all gui-less runs consistently via a single class/method then this would be redundant
- However, it does allow for a potentially testable `SimPathsStart` full run, doing a headless replication of what the GUI does to make sure it works

# Why it doesn't *actually* work

- Ideally, this should test and close testing once done. But `SimPathsStart.main()` currently cannot exit.
- So I've not yet aded the test
- `engine.startSimulation()` and never returns? Where should a return statement be added to find 'the end', but allow GUI runs to keep programme running?

# Questions

- Worth having?
- If we run a `singlerun.jar -g false -Run` test, is this best done as a maven integration test or a github actions test @igelstorm?