### PR TITLE
multirun `-DBsetup` option now checks whether training data is used

### DIFF
--- a/src/main/java/simpaths/data/Parameters.java
+++ b/src/main/java/simpaths/data/Parameters.java
@@ -3321,7 +3321,7 @@ public class Parameters {
 
         // Detect if data available; set to testing data if not
         Collection<File> testList = FileUtils.listFiles(new File(Parameters.getInputDirectoryInitialPopulations()), new String[]{"csv"}, false);
-        if (testList.size()==0)
+        if (testList.isEmpty())
             Parameters.setTrainingFlag(true);
 
         // populate new database for starting data


### PR DESCRIPTION
# What

- adds a test to the setup of multirun database setup to check if training data should be used
- mimics what `singlerun.jar -Setup` aims to do

# Why

- ideally, all setup and run can be done/tested consistently in the `SimPathsMultiRun` class
- This adds testability