### PR TITLE
180 Change all multirun testing files to use `multirun.jar -DBSetup`

### DIFF
--- a/.github/workflows/SimPathsBuild.yml
+++ b/.github/workflows/SimPathsBuild.yml
@@ -58,14 +58,14 @@ jobs:
         name: simpaths_jars
         path: .
     - name: Setup run
-      run: java -jar singlerun.jar -c UK -s 2017 -Setup -g false --rewrite-policy-schedule
+      run: java -jar multirun.jar -DBSetup -config test_create_database.yml
     - name: Check input db exists
       id: check_file
       uses: thebinaryfelix/check-file-existence-action@1.0.0
       with:
         files: 'input/input.mv.db, input/EUROMODpolicySchedule.xlsx, input/DatabaseCountryYear.xlsx'
     - name: Do two runs with persistence to root database
-      run: java -jar multirun.jar -p 20000 -s 2019 -e 2022 -r 100 -n 2 -g false --persist=root
+      run: java -jar multirun.jar -config test_run.yml --persist=root
 
   run-simpaths-no-persist:
     needs: build
@@ -82,11 +82,11 @@ jobs:
         name: simpaths_jars
         path: .
     - name: Setup run
-      run: java -jar singlerun.jar -c UK -s 2017 -Setup -g false --rewrite-policy-schedule
+      run: java -jar multirun.jar -DBSetup -config test_create_database.yml
     - name: Check input db exists
       id: check_file
       uses: thebinaryfelix/check-file-existence-action@1.0.0
       with:
         files: 'input/input.mv.db, input/EUROMODpolicySchedule.xlsx, input/DatabaseCountryYear.xlsx'
     - name: Do two runs with no persistence
-      run: java -jar multirun.jar -p 20000 -s 2019 -e 2022 -r 100 -n 2 -g false --persist=none
+      run: java -jar multirun.jar -config test_run.yml --persist=none

--- a/config/test_create_database.yml
+++ b/config/test_create_database.yml
@@ -1,0 +1,10 @@
+# FOR TESTING
+# CONFIG FILE TO CREATE NEW DATABASE OBJECTS
+
+# Arguments of the SimPathsMultiRun object overridden by the command-line
+countryString: "United Kingdom"
+executeWithGui: false
+randomSeed: 606
+startYear: 2019
+endYear: 2030
+popSize: 40000

--- a/config/test_run.yml
+++ b/config/test_run.yml
@@ -1,0 +1,17 @@
+# This file can be used to override defaults for multirun arguments.
+# Arguments of the SimPathsMultiRun object overridden by the command-line
+
+maxNumberOfRuns: 2
+executeWithGui: false
+randomSeed: 100
+startYear: 2019
+endYear: 2022
+popSize: 20000
+
+collector_args:
+    persistStatistics: true
+    persistStatistics2: true
+    persistStatistics3: true
+    persistPersons: false
+    persistBenefitUnits: false
+    persistHouseholds: false

--- a/src/main/java/simpaths/data/Parameters.java
+++ b/src/main/java/simpaths/data/Parameters.java
@@ -8,6 +8,7 @@ import java.nio.file.Files;
 import java.util.*;
 
 // import plug-in packages
+import org.apache.commons.io.FileUtils;
 import simpaths.data.startingpop.DataParser;
 import simpaths.model.AnnuityRates;
 import simpaths.model.enums.*;
@@ -3317,6 +3318,11 @@ public class Parameters {
         // remove database file if it exists
         String filePath = "./input" + File.separator + "input.mv.db";
         safeDelete(filePath);
+
+        // Detect if data available; set to testing data if not
+        Collection<File> testList = FileUtils.listFiles(new File(Parameters.getInputDirectoryInitialPopulations()), new String[]{"csv"}, false);
+        if (testList.size()==0)
+            Parameters.setTrainingFlag(true);
 
         // populate new database for starting data
         DataParser.databaseFromCSV(country, executeWithGui); // Initial database tables

--- a/src/main/java/simpaths/data/Parameters.java
+++ b/src/main/java/simpaths/data/Parameters.java
@@ -1908,8 +1908,14 @@ public class Parameters {
 
     public static TreeMap<Integer, String> calculateEUROMODpolicySchedule(Country country) {
         //Load current values for policy description and initiation year
-        MultiKeyCoefficientMap currentEUROMODpolicySchedule = ExcelAssistant.loadCoefficientMap("input" + File.separator + EUROMODpolicyScheduleFilename + ".xlsx", country.toString(), 1, 3);
-        TreeMap<Integer, String> newEUROMODpolicySchedule = new TreeMap<>();
+        MultiKeyCoefficientMap currentEUROMODpolicySchedule;
+
+        if (trainingFlag) {
+            currentEUROMODpolicySchedule = ExcelAssistant.loadCoefficientMap("input" + File.separator + "EUOROMODoutput" + File.separator + "training" + File.separator + EUROMODpolicyScheduleFilename + ".xlsx", country.toString(), 1, 3);
+        } else {
+            currentEUROMODpolicySchedule = ExcelAssistant.loadCoefficientMap("input" + File.separator + EUROMODpolicyScheduleFilename + ".xlsx", country.toString(), 1, 3);
+        }
+            TreeMap<Integer, String> newEUROMODpolicySchedule = new TreeMap<>();
 
         for(Object o: currentEUROMODpolicySchedule.keySet()) {
             MultiKey k = (MultiKey)o;

--- a/src/main/java/simpaths/data/Parameters.java
+++ b/src/main/java/simpaths/data/Parameters.java
@@ -1911,7 +1911,7 @@ public class Parameters {
         MultiKeyCoefficientMap currentEUROMODpolicySchedule;
 
         if (trainingFlag) {
-            currentEUROMODpolicySchedule = ExcelAssistant.loadCoefficientMap("input" + File.separator + "EUOROMODoutput" + File.separator + "training" + File.separator + EUROMODpolicyScheduleFilename + ".xlsx", country.toString(), 1, 3);
+            currentEUROMODpolicySchedule = ExcelAssistant.loadCoefficientMap("input" + File.separator + "EUROMODoutput" + File.separator + "training" + File.separator + EUROMODpolicyScheduleFilename + ".xlsx", country.toString(), 1, 3);
         } else {
             currentEUROMODpolicySchedule = ExcelAssistant.loadCoefficientMap("input" + File.separator + EUROMODpolicyScheduleFilename + ".xlsx", country.toString(), 1, 3);
         }

--- a/src/main/java/simpaths/data/Parameters.java
+++ b/src/main/java/simpaths/data/Parameters.java
@@ -1911,11 +1911,17 @@ public class Parameters {
         MultiKeyCoefficientMap currentEUROMODpolicySchedule;
 
         if (trainingFlag) {
-            currentEUROMODpolicySchedule = ExcelAssistant.loadCoefficientMap("input" + File.separator + "EUROMODoutput" + File.separator + "training" + File.separator + EUROMODpolicyScheduleFilename + ".xlsx", country.toString(), 1, 3);
-        } else {
-            currentEUROMODpolicySchedule = ExcelAssistant.loadCoefficientMap("input" + File.separator + EUROMODpolicyScheduleFilename + ".xlsx", country.toString(), 1, 3);
+            File trainingSchedule = new File("input" + File.separator + "EUROMODoutput" + File.separator + "training" + File.separator + EUROMODpolicyScheduleFilename + ".xlsx");
+            File runSchedule = new File("input" + File.separator + EUROMODpolicyScheduleFilename + ".xlsx");
+            try {
+                FileUtils.copyFile(trainingSchedule, runSchedule);
+            } catch (IOException e) {
+                System.err.println("Could not replace EUROMODoutput.xlsx from training data");
+            }
         }
-            TreeMap<Integer, String> newEUROMODpolicySchedule = new TreeMap<>();
+        
+        currentEUROMODpolicySchedule = ExcelAssistant.loadCoefficientMap("input" + File.separator + EUROMODpolicyScheduleFilename + ".xlsx", country.toString(), 1, 3);
+        TreeMap<Integer, String> newEUROMODpolicySchedule = new TreeMap<>();
 
         for(Object o: currentEUROMODpolicySchedule.keySet()) {
             MultiKey k = (MultiKey)o;

--- a/src/test/java/simpaths/integrationtest/RunSimPathsIntegrationTest.java
+++ b/src/test/java/simpaths/integrationtest/RunSimPathsIntegrationTest.java
@@ -25,12 +25,7 @@ public class RunSimPathsIntegrationTest {
     @Order(1)
     void testRunSetup() {
         runCommand(
-            "java", "-jar", "singlerun.jar",
-            "-c", "UK",
-            "-s", "2017",
-            "-Setup",
-            "-g", "false",
-            "--rewrite-policy-schedule"
+                "java", "-jar", "multirun.jar", "-DBSetup", "-config", "test_create_database.yml"
         );
     }
 
@@ -48,13 +43,7 @@ public class RunSimPathsIntegrationTest {
     @Order(3)
     void testRunSimulation() {
         runCommand(
-            "java", "-jar", "multirun.jar",
-            "-p", "20000",
-            "-s", "2019",
-            "-e", "2022",
-            "-r", "100",
-            "-n", "2",
-            "-g", "false"
+            "java", "-jar", "multirun.jar", "-config", "test_run.yml", "-P", "root"
         );
     }
 


### PR DESCRIPTION
# What

- changes all `singlerun.jar -Setup` calls in testing files to `multirun.jar -DBSetup` calls
- creates two new config files:
  - `test_create_database.yml`
  - `test_run.yml`
- calls respective config files in test setup/runs

# Why

- step towards resolving #177
- more consistency in use of `SimPathsMultiRun`: point towards (and test) consistency in using `multirun.jar` to both setup and run SimPaths