### PR TITLE
Add break statement at file parsing to avoid default value

### DIFF
--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -218,6 +218,7 @@ public class SimPathsMultiRun extends MultiRun {
 						log.info("Not persisting processed data");
 						persist_population = false;
 						persist_root = false;
+						break;
 					default:
 						System.out.println("Persist option `" + cmd.getOptionValue("P") + "` not recognised. Valid values: `none`, `root`, `run`. Persisting processed data to run folder");
 						persist_population = true;


### PR DESCRIPTION
# What

- closes #194 by adding break statement

# Why

- argument 'none' carrying on to default and printing confusing message