### PR TITLE
Adding getters and setters

### DIFF
--- a/src/main/java/simpaths/experiment/SimPathsCollector.java
+++ b/src/main/java/simpaths/experiment/SimPathsCollector.java
@@ -1018,4 +1018,13 @@ public class SimPathsCollector extends AbstractSimulationCollectorManager implem
     public void calculateAtRiskOfPoverty() {
         calculateEquivalisedHouseholdDisposableIncome();
     }
+
+    public boolean isPersistHealthStatistics() {
+        return persistHealthStatistics;
+    }
+
+    public void setPersistHealthStatistics(boolean persistHealthStatistics) {
+        this.persistHealthStatistics = persistHealthStatistics;
+    }
+
 }


### PR DESCRIPTION
Adding missing getters and setters for the PersistHealthStatistics method. There was a bug that prevented the GUI to build caused by the missing getter-setter method required by the Jasmine-GUI library.