### PR TITLE
change median income calculation to use hh weights #322

### DIFF
--- a/input/InitialPopulations/compile/RegressionEstimates/variable_update.do
+++ b/input/InitialPopulations/compile/RegressionEstimates/variable_update.do
@@ -149,17 +149,9 @@ summ inc_increase inc_decrease econ_incchange
 
 * Task 5
 * Poverty transitions
-// ssc install egenmore
-* Ensure all swvs have household weight
-//gen weight_house = hhdenub_xw
-//replace weight_house=hhdenus_xw if swv==1
-//replace weight_house=hhdenui_xw if swv>=6 & swv<=13
-//replace weight_house=hhdeng2_xw if swv==14
-//
-//label var weight_house "Weight: household cross-sectional"
 
 * Generate median income for sample
-bysort swv: egen samp_medianinc=wpctile(econ_realequivinc), p(50) // weights(weight_house)
+bysort swv: egen samp_medianinc=wpctile(econ_realequivinc), p(50) weights(dhhwt)
 label var samp_medianinc "Median household income for sample in swv"
 * ONS uses net income, before or after housing costs. Net income used here.
 gen samp_poverty =samp_medianinc*0.60


### PR DESCRIPTION
# What

- Adds correct household weights to calculation of median equivalised income

# Why

- This is used in calculating whether a household is in poverty or not (at <60% of the median income) and should be weighted