### PR TITLE
Add startYear guard

### DIFF
--- a/src/main/java/simpaths/data/Parameters.java
+++ b/src/main/java/simpaths/data/Parameters.java
@@ -310,7 +310,7 @@ public class Parameters {
     //public static int MAX_AGE_IN_EDUCATION;// = MAX_AGE;//30;			// Max age a person can stay in education	//Cannot set here, as MAX_AGE is not known yet.  Now set to MAX_AGE in buildObjects in Model class.
     //public static int MAX_AGE_MARRIAGE;// = MAX_AGE;//75;  			// Max age a person can marry		//Cannot set here, as MAX_AGE is not known yet.  Now set to MAX_AGE in buildObjects in Model class.
     private static int MIN_START_YEAR = 2011; //Minimum allowed starting point. Should correspond to the oldest initial population.
-    private static int MAX_START_YEAR = 2023; //Maximum allowed starting point. Should correspond to the most recent initial population.
+    private static int MAX_START_YEAR = 2024; //Maximum allowed starting point. Should correspond to the most recent initial population.
     public static int startYear;
     public static int endYear;
     private static final int MIN_START_YEAR_TESTING = 2019;
@@ -2152,6 +2152,20 @@ public class Parameters {
             return MIN_START_YEAR_TESTING;
         else
             return (trainingFlag) ? MIN_START_YEAR_TRAINING : MIN_START_YEAR;
+    }
+
+    public static void validateStartYear(int year) {
+        int min = getMinStartYear();
+        int max = getMaxStartYear();
+        if (year < min || year > max) {
+            String mode;
+            if (TESTING_FLAG) mode = "testing data";
+            else if (trainingFlag) mode = "training data";
+            else mode = "real data";
+            throw new IllegalArgumentException(
+                    "Start year " + year + " is outside the allowed range [" + min + ", " + max + "] for " + mode + ". " +
+                            "Choose a value within the supported initial-population years.");
+        }
     }
 
     public static String getEuromodOutputDirectory() {

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -107,6 +107,8 @@ public class SimPathsMultiRun extends MultiRun {
 		}
 		country = Country.getCountryFromNameString(countryString);
 
+		Parameters.validateStartYear(startYear);
+
 		//Save the last selected country and year to Excel to use in the model
 		String[] columnNames = {"Country", "Year"};
 		Object[][] data = new Object[1][columnNames.length];

--- a/src/main/java/simpaths/experiment/SimPathsStart.java
+++ b/src/main/java/simpaths/experiment/SimPathsStart.java
@@ -219,6 +219,8 @@ public class SimPathsStart implements ExperimentBuilder {
 	@Override
 	public void buildExperiment(SimulationEngine engine) {
 
+		Parameters.validateStartYear(startYear);
+
 		// instantiate simulation processes
 		SimPathsModel model = new SimPathsModel(country, startYear);
 		SimPathsCollector collector = new SimPathsCollector(model);
@@ -233,10 +235,12 @@ public class SimPathsStart implements ExperimentBuilder {
 
 	private static void runGUIlessSetup(int option) throws FileNotFoundException {
 
-		// Detect if data available; set to testing data if not
+		// Detect if data available; set to training data if not.
 		Collection<File> testList = FileUtils.listFiles(new File(Parameters.getInputDirectoryInitialPopulations()), new String[]{"csv"}, false);
 		if (testList.size()==0)
 			Parameters.setTrainingFlag(true);
+
+		Parameters.validateStartYear(startYear);
 
 		// Create EUROMODPolicySchedule input from files
 		if (!rewritePolicySchedule &&


### PR DESCRIPTION
 Validate startYear against the available initial-population and EUROMOD output range
-Add Parameters.validateStartYear(year) so a bad start year fails fast with a clear message instead of crashing later.